### PR TITLE
[TASK] Ignore `config` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.build
-var
-tailor-version-artefact
+/.build
+/config
+/var
+/tailor-version-artefact
 
-.phpunit.result.cache
-.php-cs-fixer.cache
+/.phpunit.result.cache
+/.php-cs-fixer.cache


### PR DESCRIPTION
During local development (e.g. with a local DDEV instance), a `config` file is automatically created. We should ignore this folder from version control.