### PR TITLE
[FEATURE] Add `SelfCareProvider` for meta checks on the exposed endpoint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,8 +24,8 @@ indent_size = 2
 indent_size = 2
 
 # Exclude README.md b/c of the badges
-[{README.md,SECURITY.md,architecture.md}]
-max_line_length = 200
+[{*.md}]
+max_line_length = 255
 
 # NEON-Files
 [*.neon]

--- a/Classes/Configuration/Authorizer/AdminUserAuthorizerConfiguration.php
+++ b/Classes/Configuration/Authorizer/AdminUserAuthorizerConfiguration.php
@@ -32,13 +32,13 @@ namespace mteu\Monitoring\Configuration\Authorizer;
 final readonly class AdminUserAuthorizerConfiguration implements AuthorizerConfiguration
 {
     public function __construct(
-        private bool $enabled = false,
+        private bool $isEnabled = false,
         private int $priority = -10,
     ) {}
 
     public function isEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     public function getPriority(): int

--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -25,6 +25,7 @@ namespace mteu\Monitoring\Configuration;
 
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Provider\SelfCareProviderConfiguration;
 
 /**
  * MonitoringConfiguration DTO.
@@ -38,5 +39,6 @@ final readonly class MonitoringConfiguration
         public string $endpoint,
         public TokenAuthorizerConfiguration $tokenAuthorizerConfiguration,
         public AdminUserAuthorizerConfiguration $adminUserAuthorizerConfiguration,
+        public SelfCareProviderConfiguration $selfCareProviderConfiguration,
     ) {}
 }

--- a/Classes/Configuration/MonitoringConfigurationFactory.php
+++ b/Classes/Configuration/MonitoringConfigurationFactory.php
@@ -25,6 +25,7 @@ namespace mteu\Monitoring\Configuration;
 
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Provider\SelfCareProviderConfiguration;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
@@ -61,30 +62,39 @@ final readonly class MonitoringConfigurationFactory
          *           enabled?: string|bool|int,
          *           priority?: string|bool|int|float,
          *         }
-         *      }
+         *      },
+         *     provider?: array{
+         *      enabled?: string|bool|int,
+         *      },
          *   } $config
          */
         $config = $this->extensionConfiguration->get('monitoring') ?? [];
 
         $adminUserConfig = $config['authorizer']['mteu\Monitoring\Authorization\AdminUserAuthorizer'] ?? [];
         $tokenAuthorizerConfig = $config['authorizer']['mteu\Monitoring\Authorization\TokenAuthorizer'] ?? [];
+        $selfCareProviderConfig = $config['provider']['mteu\Monitoring\Provider\SelfCareProvider'] ?? [];
 
         $adminUserConfiguration = new AdminUserAuthorizerConfiguration(
-            enabled: $this->boolean($adminUserConfig['enabled'] ?? false),
+            isEnabled: $this->boolean($adminUserConfig['enabled'] ?? false),
             priority: $this->integer($adminUserConfig['priority'] ?? -10),
         );
 
         $tokenAuthorizerConfiguration = new TokenAuthorizerConfiguration(
-            enabled: $this->boolean($tokenAuthorizerConfig['enabled'] ?? false),
+            isEnabled: $this->boolean($tokenAuthorizerConfig['enabled'] ?? false),
             priority: $this->integer($tokenAuthorizerConfig['priority'] ?? 10),
             secret: $this->string($tokenAuthorizerConfig['secret'] ?? ''),
             authHeaderName: $this->string($tokenAuthorizerConfig['authHeaderName'] ?? ''),
+        );
+
+        $selfCareProviderConfiguration = new SelfCareProviderConfiguration(
+            isEnabled: $selfCareProviderConfig['enabled'] ?? false,
         );
 
         return new MonitoringConfiguration(
             endpoint: $this->string($config['api']['endpoint'] ?? ''),
             tokenAuthorizerConfiguration: $tokenAuthorizerConfiguration,
             adminUserAuthorizerConfiguration: $adminUserConfiguration,
+            selfCareProviderConfiguration: $selfCareProviderConfiguration,
         );
     }
 

--- a/Classes/Configuration/Provider/ProviderConfiguration.php
+++ b/Classes/Configuration/Provider/ProviderConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -30,5 +31,5 @@ namespace mteu\Monitoring\Configuration\Provider;
  */
 interface ProviderConfiguration
 {
-    public function enabled(): bool;
+    public function isEnabled(): bool;
 }

--- a/Classes/Configuration/Provider/SelfCareProviderConfiguration.php
+++ b/Classes/Configuration/Provider/SelfCareProviderConfiguration.php
@@ -21,30 +21,20 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace mteu\Monitoring\Configuration\Authorizer;
+namespace mteu\Monitoring\Configuration\Provider;
 
 /**
- * TokenAuthorizerConfiguration.
+ * SelfCareProviderConfiguration.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
  */
-final readonly class TokenAuthorizerConfiguration implements AuthorizerConfiguration
+final readonly class SelfCareProviderConfiguration implements ProviderConfiguration
 {
-    public function __construct(
-        private bool $isEnabled = false,
-        private int $priority = 10,
-        public string $secret = '',
-        public string $authHeaderName = '',
-    ) {}
+    public function __construct(private bool $isEnabled = false) {}
 
     public function isEnabled(): bool
     {
         return $this->isEnabled;
-    }
-
-    public function getPriority(): int
-    {
-        return $this->priority;
     }
 }

--- a/Classes/Middleware/MonitoringMiddleware.php
+++ b/Classes/Middleware/MonitoringMiddleware.php
@@ -27,6 +27,7 @@ use mteu\Monitoring\Authorization\Authorizer;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfigurationFactory;
 use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Provider\SelfCareProvider;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -151,6 +152,11 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
 
         foreach ($this->monitoringProviders as $provider) {
             if ($provider->isActive()) {
+
+                if ($provider instanceof SelfCareProvider) {
+                    continue;
+                }
+
                 $status[$provider->getName()] = $provider->execute()->isHealthy();
             }
         }

--- a/Classes/Provider/SelfCareProvider.php
+++ b/Classes/Provider/SelfCareProvider.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\Monitoring\Provider;
+
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfigurationFactory;
+use mteu\Monitoring\Result\MonitoringResult;
+use mteu\Monitoring\Result\Result;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+/**
+ * SelfCareProvider.
+ *
+ * Monitors the health of the monitoring middleware itself by making an HTTP request
+ * to its own health endpoint. This provides a meta-level health check to ensure
+ * the monitoring system is accessible and responding correctly.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[AutoconfigureTag(name: 'monitoring.provider')]
+final readonly class SelfCareProvider implements MonitoringProvider
+{
+    private MonitoringConfiguration $monitoringConfiguration;
+
+    public function __construct(
+        private MonitoringConfigurationFactory $monitoringConfigurationFactory,
+        private ClientInterface $httpClient,
+        private RequestFactoryInterface $requestFactory,
+        private SiteFinder $siteFinder,
+        private LoggerInterface $logger,
+        private ExtensionConfiguration $extensionConfiguration,
+        private HashService $hashService,
+    ) {
+        $this->monitoringConfiguration = $this->monitoringConfigurationFactory->create();
+    }
+
+    public function getName(): string
+    {
+        return 'Endpoint Self Check';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The self-care provider monitors the monitoring middleware itself by making HTTP requests to its own
+            health endpoint, providing meta-level health checking to ensure the monitoring system is accessible and
+            responding correctly.';
+    }
+
+    public function isActive(): bool
+    {
+        // Only active if monitoring endpoint is configured and provider is enabled
+        if ($this->monitoringConfiguration->endpoint === '') {
+            return false;
+        }
+
+        // Prevent execution during self-requests by checking for the recursion protection header
+        if (array_key_exists('HTTP_X_SELFCARE_REQUEST', $_SERVER)) {
+            return false;
+        }
+
+        $config = $this->extensionConfiguration->get('monitoring') ?? [];
+        if (!is_array($config)) {
+            return true;
+        }
+
+        $providerSection = $config['provider'] ?? [];
+        if (!is_array($providerSection)) {
+            return true;
+        }
+
+        $providerConfig = $providerSection['mteu\\Monitoring\\Provider\\SelfCareProvider'] ?? [];
+        if (!is_array($providerConfig)) {
+            return true;
+        }
+
+        $enabled = $providerConfig['enabled'] ?? true;
+
+        return filter_var($enabled, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
+    }
+
+    public function execute(): Result
+    {
+        try {
+            $baseUrl = $this->getBaseUrl();
+            $monitoringUrl = rtrim($baseUrl, '/') . $this->monitoringConfiguration->endpoint;
+
+            // Create request with authorization header if token is configured
+            $request = $this->requestFactory->createRequest('GET', $monitoringUrl);
+
+            // Add recursion protection header to prevent infinite loops
+            $request = $request->withHeader('X-SELFCARE-REQUEST', '1');
+
+            // Add authorization header if token auth is enabled and configured
+            if (
+                $this->monitoringConfiguration->tokenAuthorizerConfiguration->isEnabled()
+                && $this->monitoringConfiguration->tokenAuthorizerConfiguration->secret !== ''
+            ) {
+                $token = $this->generateAuthToken();
+                $headerName = $this->monitoringConfiguration->tokenAuthorizerConfiguration->authHeaderName;
+                $request = $request->withHeader($headerName, $token);
+            }
+
+            // Make the request with a reasonable timeout
+            $response = $this->httpClient->sendRequest($request);
+
+            // Check if response indicates healthy status
+            if ($response->getStatusCode() === 200) {
+                $body = $response->getBody()->getContents();
+                $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($data) && array_key_exists('isHealthy', $data)) {
+                    $isHealthy = (bool)$data['isHealthy'];
+                    return new MonitoringResult(
+                        name: $this->getName(),
+                        isHealthy: $isHealthy,
+                        reason: $isHealthy ? null : 'Monitoring endpoint reported unhealthy state'
+                    );
+                }
+
+                return new MonitoringResult(
+                    name: $this->getName(),
+                    isHealthy: false,
+                    reason: 'Invalid response format from monitoring endpoint'
+                );
+            }
+
+            return new MonitoringResult(
+                name: $this->getName(),
+                isHealthy: false,
+                reason: sprintf('Monitoring endpoint returned HTTP %d', $response->getStatusCode())
+            );
+
+        } catch (ClientExceptionInterface $e) {
+            $this->logger->warning('SelfCare monitoring failed with HTTP client exception', [
+                'exception' => $e->getMessage(),
+                'endpoint' => $this->monitoringConfiguration->endpoint,
+            ]);
+
+            return new MonitoringResult(
+                name: $this->getName(),
+                isHealthy: false,
+                reason: 'HTTP request failed: ' . $e->getMessage()
+            );
+
+        } catch (\JsonException) {
+            return new MonitoringResult(
+                name: $this->getName(),
+                isHealthy: false,
+                reason: 'Invalid JSON response from monitoring endpoint'
+            );
+
+        } catch (\Exception $e) {
+            $this->logger->error('SelfCare monitoring failed with unexpected exception', [
+                'exception' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+
+            return new MonitoringResult(
+                name: $this->getName(),
+                isHealthy: false,
+                reason: 'Unexpected error: ' . $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * Get the base URL for the current TYPO3 site.
+     *
+     * Attempts to determine the correct base URL by checking:
+     * 1. First available site configuration
+     * 2. Fallback to HTTP_HOST from global server variables
+     * 3. Ultimate fallback to localhost
+     */
+    private function getBaseUrl(): string
+    {
+        try {
+            // Try to get base URL from site configuration
+            $sites = $this->siteFinder->getAllSites();
+            if (count($sites) > 0) {
+                $firstSite = reset($sites);
+                $base = $firstSite->getBase();
+
+                // Ensure HTTPS for monitoring endpoint access
+                if ($base->getScheme() === 'http') {
+                    $base = $base->withScheme('https');
+                }
+
+                return (string)$base;
+            }
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not determine base URL from site configuration', [
+                'exception' => $e->getMessage(),
+            ]);
+        }
+
+        // Fallback to HTTP_HOST
+        $httpHost = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? 'localhost';
+        if (!is_string($httpHost)) {
+            $httpHost = 'localhost';
+        }
+        $scheme = 'https'; // Always use HTTPS for monitoring endpoints
+
+        return sprintf('%s://%s', $scheme, $httpHost);
+    }
+
+    private function generateAuthToken(): string
+    {
+        /** @var non-empty-string $additionalSecret */
+        $additionalSecret = $this->monitoringConfiguration->tokenAuthorizerConfiguration->secret;
+
+        return $this->hashService->hmac(
+            $this->monitoringConfiguration->endpoint,
+            $additionalSecret,
+        );
+    }
+}

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -52,6 +52,8 @@ logged in to the TYPO3 backend.
 }
 ```
 
+**Note**: The built-in `SelfCareProvider` is never included in the `services` object when accessed via HTTP. The middleware skips it entirely since a successful HTTP response already proves the monitoring system is working.
+
 ### Unhealthy Response
 
 **Status Code**: `503 Service Unavailable`

--- a/Documentation/backend.md
+++ b/Documentation/backend.md
@@ -31,7 +31,7 @@ Each provider displays:
 For cacheable providers:
 - View cache lifetime and expiration
 - Flush provider cache via "Flush Cache" link
-- Flash messages use queue identifier: `'typo3_monitoring'`
+- Flash messages use queue identifier: `'ext_monitoring_message_queue'`
 
 ### Authorization Information
 

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -24,6 +24,11 @@ return [
                     'priority' => -10,
                 ],
             ],
+            'provider' => [
+                'mteu\Monitoring\Provider\SelfCareProvider' => [
+                    'enabled' => true,
+                ],
+            ],
         ],
     ],
 ];
@@ -50,7 +55,24 @@ return [
 
 ## Provider Configuration
 
-Providers are auto-discovered via dependency injection. To disable a provider:
+Providers are auto-discovered via dependency injection and can be configured via extension configuration.
+
+### Built-in Provider Configuration
+
+#### SelfCareProvider
+- **`enabled`**: Enable/disable the SelfCareProvider (default: `true`)
+
+```php
+'provider' => [
+    'mteu\Monitoring\Provider\SelfCareProvider' => [
+        'enabled' => true,
+    ],
+],
+```
+
+### Custom Provider Configuration
+
+To disable a custom provider via service configuration:
 
 ```yaml
 # Configuration/Services.yaml

--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -28,7 +28,14 @@ return [
         'monitoring' => [
             'api' => [
                 'endpoint' => '/monitor/health',
-                'secret' => 'your-secure-secret',
+            ],
+            'authorizer' => [
+                'mteu\Monitoring\Authorization\TokenAuthorizer' => [
+                    'enabled' => true,
+                    'secret' => 'your-secure-secret',
+                    'authHeaderName' => 'X-TYPO3-MONITORING-AUTH',
+                    'priority' => 10,
+                ],
             ],
         ],
     ],

--- a/Documentation/middleware.md
+++ b/Documentation/middleware.md
@@ -154,8 +154,6 @@ if ($provider instanceof SelfCareProvider) {
 }
 ```
 
-The SelfCareProvider is only useful when called externally (CLI commands, external monitoring tools) to verify the monitoring endpoint accessibility from outside the application.
-
 ## Error Handling
 
 The middleware handles errors gracefully:

--- a/Documentation/middleware.md
+++ b/Documentation/middleware.md
@@ -135,6 +135,27 @@ private function getHealthStatus(): array
 }
 ```
 
+## Provider Execution
+
+The middleware executes all active providers and collects their health status. Special handling is applied to certain providers:
+
+### SelfCareProvider Handling
+
+The built-in `SelfCareProvider` is completely excluded from middleware execution for logical and performance reasons:
+
+- **Redundancy**: If the middleware can respond, the monitoring system is already working
+- **Performance**: Avoids unnecessary HTTP requests to itself during monitoring requests
+- **Logic**: The middleware's successful response IS the self-check
+
+```php
+// SelfCareProvider is completely skipped in middleware execution
+if ($provider instanceof SelfCareProvider) {
+    continue; // Skip execution entirely
+}
+```
+
+The SelfCareProvider is only useful when called externally (CLI commands, external monitoring tools) to verify the monitoring endpoint accessibility from outside the application.
+
 ## Error Handling
 
 The middleware handles errors gracefully:
@@ -142,3 +163,4 @@ The middleware handles errors gracefully:
 - JSON encoding errors are logged and fall back to the next middleware
 - Invalid configurations result in passing requests to the next middleware
 - Authorization failures return structured error responses
+- Provider exceptions are caught and reported as unhealthy status

--- a/Documentation/providers.md
+++ b/Documentation/providers.md
@@ -279,37 +279,24 @@ final class MultiComponentProvider implements MonitoringProvider
 }
 ```
 
-## 📝 Provider Patterns
-Here's quick glance at what custom providers might be able to achieve.
+## 📦 Built-in Providers
 
-### Health Check Patterns
+The monitoring extension includes several built-in providers:
 
-@todo
+### SelfCareProvider
 
-### Error Handling
+The `SelfCareProvider` monitors the health of the monitoring middleware itself by making HTTP requests to its own health endpoint. This provides meta-level monitoring to ensure the monitoring system is accessible and responding correctly.
 
-Always implement proper error handling:
-
-```php
-public function execute(): Result
-{
-    try {
-        $isHealthy = $this->performCheck();
-
-        return new MonitoringResult(
-            name: $this->getName(),
-            isHealthy: $isHealthy,
-            reason: $isHealthy ? null : 'Service check failed'
-        );
-    } catch (\Exception $e) {
-        return new MonitoringResult(
-            name: $this->getName(),
-            isHealthy: false,
-            reason: 'Exception: ' . $e->getMessage()
-        );
+**Configuration:**
+```yaml
+# ext_conf_template.txt
+provider {
+    mteu\Monitoring\Provider\SelfCareProvider {
+        enabled=1
     }
 }
 ```
+**Note**: The SelfCareProvider is automatically excluded from HTTP middleware execution to avoid redundancy and unnecessary performance overhead. A successful HTTP response from the monitoring endpoint already proves the system is working.
 
 ## ⚙️ Configuration
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ post-deployment checks.
 
 - [Extensible monitoring system](Documentation/architecture.md) with automatic service discovery (using DI) for custom
   authorization and monitoring checks.
+- Built-in **SelfCareProvider** for meta-level monitoring of the monitoring system itself
 - Supports caching for expensive monitoring operations
 - Delivers health reports in three ways:
   - **JSON response**: Returns structured responses for the overall health status

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -23,5 +23,8 @@ authorizer {
 }
 
 provider {
-    # ..
+    mteu\Monitoring\Provider\SelfCareProvider {
+        # cat=SelfCareProvider/Enabled; type=boolean; label=Enable SelfCareProvider:Enables monitoring of the monitoring middleware itself by making self-requests
+        enabled=1
+    }
 }


### PR DESCRIPTION
This PR implements a `SelfCareProvider` that performs meta-level monitoring of the monitoring middleware itself by making HTTP requests to its own health endpoint. This provides end-to-end verification that the monitoring system is accessible and responding correctly from external perspectives. It's only executed in the `monitoring:run`-Command and the Backend module.