### PR TITLE
[FEATURE] Display error for unexpected monitoring api behavior

### DIFF
--- a/Classes/Authorization/TokenAuthorizer.php
+++ b/Classes/Authorization/TokenAuthorizer.php
@@ -21,6 +21,7 @@ use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
 use mteu\Monitoring\Crypto\HashServiceFactory;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -58,10 +59,20 @@ final readonly class TokenAuthorizer implements Authorizer
             return false;
         }
 
-        /** @phpstan-ignore staticMethod.deprecatedClass, method.internalClass, method.deprecatedClass */
-        return HashServiceFactory::create()->validateHmac(
-            $this->configuration->endpoint,
-            $this->tokenAuthorizerConfiguration->secret,
+        /** @phpstan-ignore staticMethod.deprecatedClass */
+        $hashService = HashServiceFactory::create();
+
+        if ($hashService instanceof HashService) {
+            return $hashService->validateHmac(
+                $this->configuration->endpoint,
+                $this->tokenAuthorizerConfiguration->secret,
+                $authToken,
+            );
+        }
+
+        /** @phpstan-ignore method.deprecatedClass, method.internalClass */
+        return $hashService->validateHmac(
+            $this->configuration->endpoint . $this->tokenAuthorizerConfiguration->secret,
             $authToken,
         );
     }

--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -104,9 +104,9 @@ final readonly class MonitoringController
             'authorizers' => $this->buildAuthorizerTemplateVariables(),
             'authorizerInterface' => Authorizer::class,
             'endpoint' => $params->getRequestHost() . $this->monitoringConfiguration->endpoint,
-            'isMiddlewareHealthy' => $this->executionHandler->executeProvider(
+            'middlewareStatusResult' => $this->executionHandler->executeProvider(
                 $this->getMiddlewareStatusProvider(),
-            )->isHealthy(),
+            ),
             'providers' => $this->buildProviderTemplateVariables(),
             'providerInterface' => MonitoringProvider::class,
             'monitoringMessageQueueIdentifier' => self::FLASHMESSAGE_QUEUE_IDENTIFIER,
@@ -125,7 +125,7 @@ final readonly class MonitoringController
             }
         }
 
-        throw new \LogicException('SelfCareProvider not found among tagged services.');
+        throw new \LogicException('MiddlewareStatusProvider not found among tagged services.');
     }
     /**
      * Process authorizers and build template variables

--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Http\AllowedMethodsTrait;
 use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
 use TYPO3\CMS\Core\Http\NormalizedParams;
@@ -181,10 +182,17 @@ final readonly class MonitoringController
         if ($secret === '') {
             return '';
         }
-        /** @phpstan-ignore method.notFound, staticMethod.deprecatedClass */
-        return HashServiceFactory::create()->hmac(
-            $this->monitoringConfiguration->endpoint,
-            $secret
+
+        /** @phpstan-ignore staticMethod.deprecatedClass */
+        $hashService = HashServiceFactory::create();
+
+        if ($hashService instanceof HashService) {
+            return $hashService->hmac($this->monitoringConfiguration->endpoint, $secret);
+        }
+
+        /** @phpstan-ignore method.deprecatedClass, method.internalClass */
+        return $hashService->generateHmac(
+            $this->monitoringConfiguration->endpoint . $secret
         );
     }
 

--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -19,7 +19,7 @@ namespace mteu\Monitoring\Configuration;
 
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
-use mteu\Monitoring\Configuration\Provider\SelfCareProviderConfiguration;
+use mteu\Monitoring\Configuration\Provider\MiddlewareStatusProviderConfiguration;
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
@@ -35,7 +35,7 @@ final readonly class MonitoringConfiguration
     public function __construct(
         public TokenAuthorizerConfiguration $tokenAuthorizerConfiguration,
         public AdminUserAuthorizerConfiguration $adminUserAuthorizerConfiguration,
-        public SelfCareProviderConfiguration $selfCareProviderConfiguration,
+        public MiddlewareStatusProviderConfiguration $providerConfiguration,
         #[ExtConfProperty(path: 'api.endpoint')]
         public string $endpoint = 'monitor/health',
     ) {}

--- a/Classes/Configuration/Provider/MiddlewareStatusProviderConfiguration.php
+++ b/Classes/Configuration/Provider/MiddlewareStatusProviderConfiguration.php
@@ -21,16 +21,16 @@ use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
 /**
- * SelfCareProviderConfiguration.
+ * MiddlewareStatusProviderConfiguration.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
  */
 #[ExtensionConfig(extensionKey: 'monitoring')]
-final readonly class SelfCareProviderConfiguration implements ProviderConfiguration
+final readonly class MiddlewareStatusProviderConfiguration implements ProviderConfiguration
 {
     public function __construct(
-        #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SelfCareProvider.enabled')]
+        #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\MiddlewareStatusProvider.enabled')]
         private bool $enabled = true,
     ) {}
 

--- a/Classes/Provider/MiddlewareStatusProvider.php
+++ b/Classes/Provider/MiddlewareStatusProvider.php
@@ -25,6 +25,7 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Site\SiteFinder;
 
 /**
@@ -181,10 +182,16 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
         /** @var non-empty-string $additionalSecret */
         $additionalSecret = $this->monitoringConfiguration->tokenAuthorizerConfiguration->secret;
 
-        /** @phpstan-ignore method.notFound, staticMethod.deprecatedClass */
-        return HashServiceFactory::create()->hmac(
-            $this->monitoringConfiguration->endpoint,
-            $additionalSecret,
+        /** @phpstan-ignore staticMethod.deprecatedClass */
+        $hashService = HashServiceFactory::create();
+
+        if ($hashService instanceof HashService) {
+            return $hashService->hmac($this->monitoringConfiguration->endpoint, $additionalSecret);
+        }
+
+        /** @phpstan-ignore method.deprecatedClass, method.internalClass */
+        return $hashService->generateHmac(
+            $this->monitoringConfiguration->endpoint . $additionalSecret
         );
     }
 }

--- a/Classes/Provider/MiddlewareStatusProvider.php
+++ b/Classes/Provider/MiddlewareStatusProvider.php
@@ -62,17 +62,16 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
 
     public function isActive(): bool
     {
-        // Only active if monitoring endpoint is configured and provider is enabled
         if ($this->monitoringConfiguration->endpoint === '') {
             return false;
         }
 
         // Prevent execution during self-requests by checking for the recursion protection header
-        if (array_key_exists('HTTP_X_SELFCARE_REQUEST', $_SERVER)) {
+        if (array_key_exists('HTTP_X_MIDDLEWARE_STATUS_REQUEST', $_SERVER)) {
             return false;
         }
 
-        return $this->monitoringConfiguration->selfCareProviderConfiguration->isEnabled();
+        return $this->monitoringConfiguration->providerConfiguration->isEnabled();
     }
 
     public function execute(): Result
@@ -81,13 +80,11 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
             $baseUrl = $this->getBaseUrl();
             $monitoringUrl = rtrim($baseUrl, '/') . $this->monitoringConfiguration->endpoint;
 
-            // Create request with authorization header if token is configured
             $request = $this->requestFactory->createRequest('GET', $monitoringUrl);
 
             // Add recursion protection header to prevent infinite loops
-            $request = $request->withHeader('X-SELFCARE-REQUEST', '1');
+            $request = $request->withHeader('X-MIDDLEWARE-STATUS-REQUEST', '1');
 
-            // Add authorization header if token auth is enabled and configured
             if (
                 $this->monitoringConfiguration->tokenAuthorizerConfiguration->isEnabled()
                 && $this->monitoringConfiguration->tokenAuthorizerConfiguration->secret !== ''
@@ -97,27 +94,13 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
                 $request = $request->withHeader($headerName, $token);
             }
 
-            // Make the request with a reasonable timeout
             $response = $this->httpClient->sendRequest($request);
 
-            // Check if response indicates healthy status
-            if ($response->getStatusCode() === 200) {
-                $body = $response->getBody()->getContents();
-                $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
-
-                if (is_array($data) && array_key_exists('isHealthy', $data)) {
-                    $isHealthy = (bool)$data['isHealthy'];
-                    return new MonitoringResult(
-                        name: $this->getName(),
-                        isHealthy: $isHealthy,
-                        reason: $isHealthy ? null : 'Monitoring endpoint reported unhealthy state'
-                    );
-                }
-
+            if ($response->getStatusCode() === 200 || $response->getStatusCode() === 503) {
                 return new MonitoringResult(
                     name: $this->getName(),
-                    isHealthy: false,
-                    reason: 'Invalid response format from monitoring endpoint'
+                    isHealthy: true,
+                    reason: null
                 );
             }
 
@@ -128,7 +111,7 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
             );
 
         } catch (ClientExceptionInterface $e) {
-            $this->logger->warning('SelfCare monitoring failed with HTTP client exception', [
+            $this->logger->warning('MiddlewareStatus monitoring failed with HTTP client exception', [
                 'exception' => $e->getMessage(),
                 'endpoint' => $this->monitoringConfiguration->endpoint,
             ]);
@@ -139,15 +122,8 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
                 reason: 'HTTP request failed: ' . $e->getMessage()
             );
 
-        } catch (\JsonException) {
-            return new MonitoringResult(
-                name: $this->getName(),
-                isHealthy: false,
-                reason: 'Invalid JSON response from monitoring endpoint'
-            );
-
         } catch (\Exception $e) {
-            $this->logger->error('SelfCare monitoring failed with unexpected exception', [
+            $this->logger->error('MiddlewareStatus monitoring failed with unexpected exception', [
                 'exception' => $e->getMessage(),
                 'file' => $e->getFile(),
                 'line' => $e->getLine(),

--- a/Resources/Private/Language/de.locallang.be.xlf
+++ b/Resources/Private/Language/de.locallang.be.xlf
@@ -135,6 +135,14 @@
 				<source>Failed to flush cache for provider "%s".</source>
 				<target>Fehler beim Leeren des Caches für Provider "%s".</target>
 			</trans-unit>
+			<trans-unit id="api.error.title">
+				<source>API Error</source>
+				<target>API-Fehler</target>
+			</trans-unit>
+			<trans-unit id="api.error.message">
+				<source>Check the endpoint at:</source>
+				<target>Überprüfe den Endpunkt unter:</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.be.xlf
+++ b/Resources/Private/Language/locallang.be.xlf
@@ -102,6 +102,12 @@
 			<trans-unit id="provider.cache.flush.error.message">
 				<source>Failed to flush cache for provider "%s".</source>
 			</trans-unit>
+			<trans-unit id="api.error.title">
+				<source>API Error</source>
+			</trans-unit>
+			<trans-unit id="api.error.message">
+				<source>Check the endpoint at:</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Backend/Monitoring.html
+++ b/Resources/Private/Templates/Backend/Monitoring.html
@@ -9,6 +9,15 @@
 <f:layout name="Module" />
 
 <f:section name="Content">
+    <f:if condition="{middlewareStatusResult.isHealthy} == false">
+        <f:be.infobox
+            title="{f:translate(key: 'LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf:api.error.title')}"
+            state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_ERROR')}">
+            <p>
+                {middlewareStatusResult.reason}. <f:translate key="LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf:api.error.message" /> <f:link.external uri="{endpoint}" target="_blank">{endpoint}</f:link.external>
+            </p>
+        </f:be.infobox>
+    </f:if>
 
     <f:flashMessages queueIdentifier="{monitoringMessageQueueIdentifier}" />
 

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -55,21 +55,6 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
     }
 
     /**
-     * @param mixed[] $configurationData
-     */
-    private function createConfigurationFromData(array $configurationData): MonitoringConfiguration
-    {
-        $this->extensionConfiguration->expects(self::atLeastOnce())
-            ->method('get')
-            ->with('monitoring')
-            ->willReturn($configurationData);
-
-        $mapperFactory = new TreeMapperFactory();
-        $provider = new TypedExtensionConfigurationProvider($this->extensionConfiguration, $mapperFactory);
-        return $provider->get(MonitoringConfiguration::class);
-    }
-
-    /**
      * @param array{
      * api: array{endpoint: string},
      * authorizer: array<string, array{enabled: string, secret: string, priority: string, authHeaderName: string}>
@@ -166,6 +151,21 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
 
         // Verify high priority authorizer was called before low priority
         self::assertSame(['high', 'low'], $callOrder);
+    }
+
+    /**
+     * @param mixed[] $configurationData
+     */
+    private function createConfigurationFromData(array $configurationData): MonitoringConfiguration
+    {
+        $this->extensionConfiguration->expects(self::atLeastOnce())
+            ->method('get')
+            ->with('monitoring')
+            ->willReturn($configurationData);
+
+        $mapperFactory = new TreeMapperFactory();
+        $provider = new TypedExtensionConfigurationProvider($this->extensionConfiguration, $mapperFactory);
+        return $provider->get(MonitoringConfiguration::class);
     }
 
     private function createRequestMock(string $path, string $scheme = 'https'): ServerRequestInterface&MockObject

--- a/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
+++ b/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
@@ -34,8 +34,11 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService as ExtbaseHashService;
 
 #[Framework\Attributes\CoversClass(MiddlewareStatusProvider::class)]
 final class MiddlewareStatusProviderTest extends Framework\TestCase
@@ -44,7 +47,9 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
     private RequestFactoryInterface&MockObject $requestFactory;
     private SiteFinder&MockObject $siteFinder;
     private LoggerInterface&MockObject $logger;
-    private HashService $hashService;
+
+    /** @phpstan-ignore property.deprecatedClass, property.internalClass */
+    private HashService|ExtbaseHashService $hashService;
 
     protected function setUp(): void
     {
@@ -56,7 +61,14 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
         $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
         $this->siteFinder = $this->createMock(SiteFinder::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->hashService = new HashService();
+
+        $typo3Version = new Typo3Version();
+        if ($typo3Version->getMajorVersion() < 13) {
+            /** @phpstan-ignore classConstant.deprecatedClass, classConstant.internalClass */
+            $this->hashService = GeneralUtility::makeInstance(ExtbaseHashService::class);
+        } else {
+            $this->hashService = new HashService();
+        }
 
         $this->setupSiteFinder();
     }
@@ -174,6 +186,7 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
             $this->requestFactory,
             $this->siteFinder,
             $this->logger,
+            /** @phpstan-ignore argument.type */
             $this->hashService
         );
     }

--- a/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
+++ b/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
@@ -33,12 +33,8 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
-use TYPO3\CMS\Core\Crypto\HashService;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Security\Cryptography\HashService as ExtbaseHashService;
 
 #[Framework\Attributes\CoversClass(MiddlewareStatusProvider::class)]
 final class MiddlewareStatusProviderTest extends Framework\TestCase
@@ -47,9 +43,6 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
     private RequestFactoryInterface&MockObject $requestFactory;
     private SiteFinder&MockObject $siteFinder;
     private LoggerInterface&MockObject $logger;
-
-    /** @phpstan-ignore property.deprecatedClass, property.internalClass */
-    private HashService|ExtbaseHashService $hashService;
 
     protected function setUp(): void
     {
@@ -61,14 +54,6 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
         $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
         $this->siteFinder = $this->createMock(SiteFinder::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-
-        $typo3Version = new Typo3Version();
-        if ($typo3Version->getMajorVersion() < 13) {
-            /** @phpstan-ignore classConstant.deprecatedClass, classConstant.internalClass */
-            $this->hashService = GeneralUtility::makeInstance(ExtbaseHashService::class);
-        } else {
-            $this->hashService = new HashService();
-        }
 
         $this->setupSiteFinder();
     }
@@ -186,8 +171,6 @@ final class MiddlewareStatusProviderTest extends Framework\TestCase
             $this->requestFactory,
             $this->siteFinder,
             $this->logger,
-            /** @phpstan-ignore argument.type */
-            $this->hashService
         );
     }
 

--- a/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
+++ b/Tests/Unit/Provider/MiddlewareStatusProviderTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Provider;
+
+use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Provider\MiddlewareStatusProviderConfiguration;
+use mteu\Monitoring\Provider\MiddlewareStatusProvider;
+use mteu\Monitoring\Result\MonitoringResult;
+use PHPUnit\Framework;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+#[Framework\Attributes\CoversClass(MiddlewareStatusProvider::class)]
+final class MiddlewareStatusProviderTest extends Framework\TestCase
+{
+    private ClientInterface&MockObject $httpClient;
+    private RequestFactoryInterface&MockObject $requestFactory;
+    private SiteFinder&MockObject $siteFinder;
+    private LoggerInterface&MockObject $logger;
+    private HashService $hashService;
+
+    protected function setUp(): void
+    {
+        // Initialize TYPO3 configuration for HashService
+        // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'test-encryption-key-for-unit-tests';
+
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->siteFinder = $this->createMock(SiteFinder::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->hashService = new HashService();
+
+        $this->setupSiteFinder();
+    }
+
+    #[Test]
+    public function getName(): void
+    {
+        $provider = $this->createProvider();
+        self::assertSame('MiddlewareStatus', $provider->getName());
+    }
+
+    #[Test]
+    public function getDescription(): void
+    {
+        $provider = $this->createProvider();
+        $description = $provider->getDescription();
+        self::assertStringContainsString('meta-provider', $description);
+        self::assertStringContainsString('monitoring middleware', $description);
+    }
+
+    #[Test]
+    #[DataProvider('inactiveConditions')]
+    public function isActiveReturnsFalseWhenConditionsNotMet(
+        string $endpoint,
+        bool $providerEnabled,
+        bool $hasRecursionHeader
+    ): void {
+        if ($hasRecursionHeader) {
+            $_SERVER['HTTP_X_MIDDLEWARE_STATUS_REQUEST'] = '1';
+        }
+
+        try {
+            $provider = $this->createProvider($endpoint, $providerEnabled);
+            self::assertFalse($provider->isActive());
+        } finally {
+            unset($_SERVER['HTTP_X_MIDDLEWARE_STATUS_REQUEST']);
+        }
+    }
+
+    #[Test]
+    public function isActiveReturnsTrueWhenConditionsMet(): void
+    {
+        $provider = $this->createProvider();
+        self::assertTrue($provider->isActive());
+    }
+
+    #[Test]
+    #[DataProvider('httpStatusCodes')]
+    public function executeHandlesHttpStatusCodes(int $statusCode, bool $expectedHealthy): void
+    {
+        $provider = $this->createProvider();
+        $this->setupHttpResponse($statusCode);
+
+        $result = $provider->execute();
+
+        self::assertInstanceOf(MonitoringResult::class, $result);
+        self::assertSame($expectedHealthy, $result->isHealthy());
+        self::assertSame('MiddlewareStatus', $result->getName());
+
+        if (!$expectedHealthy) {
+            $reason = $result->getReason();
+            self::assertIsString($reason);
+            self::assertStringContainsString((string)$statusCode, $reason);
+        }
+    }
+
+    /**
+     * @param 'warning'|'error' $expectedLogMethod
+     */
+    #[Test]
+    #[DataProvider('exceptionTypes')]
+    public function executeHandlesExceptions(
+        \Exception $exception,
+        string $expectedLogMethod,
+        string $expectedReasonSubstring
+    ): void {
+        $provider = $this->createProvider();
+        $this->setupHttpException($exception);
+
+        $this->logger
+            ->expects(self::once())
+            ->method($expectedLogMethod);
+
+        $result = $provider->execute();
+
+        self::assertInstanceOf(MonitoringResult::class, $result);
+        self::assertFalse($result->isHealthy());
+        $reason = $result->getReason();
+        self::assertIsString($reason);
+        self::assertStringContainsString($expectedReasonSubstring, $reason);
+    }
+
+    private function createProvider(
+        string $endpoint = '/monitor/health',
+        bool $providerEnabled = true
+    ): MiddlewareStatusProvider {
+        $configuration = new MonitoringConfiguration(
+            tokenAuthorizerConfiguration: new TokenAuthorizerConfiguration(
+                enabled: true,
+                priority: 10,
+                secret: 'test-secret',
+                authHeaderName: 'X-AUTH'
+            ),
+            adminUserAuthorizerConfiguration: new AdminUserAuthorizerConfiguration(
+                enabled: false,
+                priority: -10
+            ),
+            providerConfiguration: new MiddlewareStatusProviderConfiguration($providerEnabled),
+            endpoint: $endpoint
+        );
+
+        return new MiddlewareStatusProvider(
+            $configuration,
+            $this->httpClient,
+            $this->requestFactory,
+            $this->siteFinder,
+            $this->logger,
+            $this->hashService
+        );
+    }
+
+    private function setupSiteFinder(): void
+    {
+        $site = $this->createMock(Site::class);
+        $uri = $this->createMock(\Psr\Http\Message\UriInterface::class);
+
+        $uri->method('getScheme')->willReturn('https');
+        $uri->method('withScheme')->willReturn($uri);
+        $uri->method('__toString')->willReturn('https://example.com');
+
+        $site->method('getBase')->willReturn($uri);
+        $this->siteFinder->method('getAllSites')->willReturn([$site]);
+    }
+
+    private function setupHttpResponse(int $statusCode): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withHeader')->willReturn($request);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+
+        $this->requestFactory->method('createRequest')->willReturn($request);
+        $this->httpClient->method('sendRequest')->willReturn($response);
+    }
+
+    private function setupHttpException(\Exception $exception): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withHeader')->willReturn($request);
+
+        $this->requestFactory->method('createRequest')->willReturn($request);
+        $this->httpClient->method('sendRequest')->willThrowException($exception);
+    }
+
+    public static function inactiveConditions(): \Generator
+    {
+        yield 'empty endpoint' => ['', true, false];
+        yield 'disabled provider' => ['/monitor/health', false, false];
+        yield 'recursion header present' => ['/monitor/health', true, true];
+    }
+
+    public static function httpStatusCodes(): \Generator
+    {
+        yield 'HTTP 200 OK' => [200, true];
+        yield 'HTTP 503 Service Unavailable' => [503, true];
+        yield 'HTTP 401 Unauthorized' => [401, false];
+        yield 'HTTP 403 Forbidden' => [403, false];
+        yield 'HTTP 404 Not Found' => [404, false];
+        yield 'HTTP 500 Internal Server Error' => [500, false];
+    }
+
+    public static function exceptionTypes(): \Generator
+    {
+        $clientException = new class ('Connection failed') extends \Exception implements ClientExceptionInterface {};
+
+        yield 'client exception' => [$clientException, 'warning', 'HTTP request failed'];
+        yield 'unexpected exception' => [new \RuntimeException('Unexpected error'), 'error', 'Unexpected error'];
+    }
+}

--- a/Tests/Unit/ViewHelper/ClassNameViewHelperTest.php
+++ b/Tests/Unit/ViewHelper/ClassNameViewHelperTest.php
@@ -31,6 +31,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class ClassNameViewHelperTest extends UnitTestCase
 {
+    protected bool $resetSingletonInstances = true;
+    
     private ClassNameViewHelper $subject;
 
     protected function setUp(): void

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -23,8 +23,8 @@ authorizer {
 }
 
 provider {
-    mteu\Monitoring\Provider\SelfCareProvider {
-        # cat=SelfCareProvider/Enabled; type=boolean; label=Enable SelfCareProvider:Enables monitoring of the monitoring middleware itself by making self-requests
+    mteu\Monitoring\Provider\MiddlewareStatusProvider {
+        # cat=MiddlewareStatusProvider/Enabled; type=boolean; label=Enable MiddlewareStatusProvider:Enables monitoring of the monitoring middleware itself by making self-requests
         enabled=1
     }
 }


### PR DESCRIPTION
* The `MiddlewareStatusProvider` acts purely as a meta-provider to be used in the backend module to check whether the API is returning somewhat  realistic responses (as in `200` or `503`).

<img width="740" height="517" alt="image" src="https://github.com/user-attachments/assets/4075d962-ec0c-4f05-9d7b-40b46255e474" />
