### PR TITLE
[TASK] Retrieve adequate HashService instance from factory

### DIFF
--- a/Classes/Authorization/TokenAuthorizer.php
+++ b/Classes/Authorization/TokenAuthorizer.php
@@ -19,8 +19,8 @@ namespace mteu\Monitoring\Authorization;
 
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Crypto\HashServiceFactory;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -34,7 +34,6 @@ final readonly class TokenAuthorizer implements Authorizer
     private TokenAuthorizerConfiguration $tokenAuthorizerConfiguration;
 
     public function __construct(
-        private HashService $hashService,
         private MonitoringConfiguration $configuration,
     ) {
         $this->tokenAuthorizerConfiguration = $this->configuration->tokenAuthorizerConfiguration;
@@ -59,7 +58,8 @@ final readonly class TokenAuthorizer implements Authorizer
             return false;
         }
 
-        return $this->hashService->validateHmac(
+        /** @phpstan-ignore staticMethod.deprecatedClass, method.internalClass, method.deprecatedClass */
+        return HashServiceFactory::create()->validateHmac(
             $this->configuration->endpoint,
             $this->tokenAuthorizerConfiguration->secret,
             $authToken,

--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -21,6 +21,7 @@ use mteu\Monitoring\Authorization\Authorizer;
 use mteu\Monitoring\Authorization\TokenAuthorizer;
 use mteu\Monitoring\Cache\MonitoringCacheManager;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Crypto\HashServiceFactory;
 use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Provider\CacheableMonitoringProvider;
 use mteu\Monitoring\Provider\MiddlewareStatusProvider;
@@ -34,7 +35,6 @@ use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Http\AllowedMethodsTrait;
 use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
 use TYPO3\CMS\Core\Http\NormalizedParams;
@@ -69,7 +69,6 @@ final readonly class MonitoringController
         #[AutowireIterator(tag: 'monitoring.authorizer', defaultPriorityMethod: 'getPriority')]
         private iterable $authorizers,
         private ModuleTemplateFactory $moduleTemplateFactory,
-        private HashService $hashService,
         private FlashMessageService $flashMessageService,
         private LanguageServiceFactory $languageServiceFactory,
         private MonitoringExecutionHandler $executionHandler,
@@ -182,7 +181,8 @@ final readonly class MonitoringController
         if ($secret === '') {
             return '';
         }
-        return $this->hashService->hmac(
+        /** @phpstan-ignore method.notFound, staticMethod.deprecatedClass */
+        return HashServiceFactory::create()->hmac(
             $this->monitoringConfiguration->endpoint,
             $secret
         );

--- a/Classes/Crypto/HashServiceFactory.php
+++ b/Classes/Crypto/HashServiceFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Crypto;
+
+use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService as ExtbaseHashService;
+
+/**
+ * HashServiceFactory.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ *
+ * @deprecated Will be removed once support for v12 is dropped
+ * @internal
+ */
+final readonly class HashServiceFactory
+{
+    /** @phpstan-ignore return.internalClass  */
+    public static function create(): HashService|ExtbaseHashService
+    {
+        $typo3 = new Typo3Version();
+
+        if ($typo3->getMajorVersion() >= 13) {
+            return new HashService();
+        }
+
+        /** @phpstan-ignore classConstant.internalClass */
+        return GeneralUtility::makeInstance(ExtbaseHashService::class);
+    }
+}

--- a/Classes/Provider/MiddlewareStatusProvider.php
+++ b/Classes/Provider/MiddlewareStatusProvider.php
@@ -18,13 +18,13 @@ declare(strict_types=1);
 namespace mteu\Monitoring\Provider;
 
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Crypto\HashServiceFactory;
 use mteu\Monitoring\Result\MonitoringResult;
 use mteu\Monitoring\Result\Result;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Log\LoggerInterface;
-use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Site\SiteFinder;
 
 /**
@@ -47,7 +47,6 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
         private RequestFactoryInterface $requestFactory,
         private SiteFinder $siteFinder,
         private LoggerInterface $logger,
-        private HashService $hashService,
     ) {}
 
     public function getName(): string
@@ -206,7 +205,8 @@ final readonly class MiddlewareStatusProvider implements MonitoringProvider
         /** @var non-empty-string $additionalSecret */
         $additionalSecret = $this->monitoringConfiguration->tokenAuthorizerConfiguration->secret;
 
-        return $this->hashService->hmac(
+        /** @phpstan-ignore method.notFound, staticMethod.deprecatedClass */
+        return HashServiceFactory::create()->hmac(
             $this->monitoringConfiguration->endpoint,
             $additionalSecret,
         );

--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -29,6 +29,7 @@ $configuration
     ->addPathsToExclude([
         $rootPath . '/Tests/CGL',
     ])
+    ->ignoreErrorsOnPath( $rootPath . '/Classes/Crypto', [ComposerDependencyAnalyser\Config\ErrorType::SHADOW_DEPENDENCY])
 ;
 
 return $configuration;


### PR DESCRIPTION
We're in a bit of a pickle wanting to add backwards compability to v12 with this extension since some functionality relies on the `TYPO3\CMS\Core\Crypto\HashService` that does not yet exist in v12. Hence this new factory to spit out the correct class.