### PR TITLE
[TASK] Make HTTPS enforcement optional

### DIFF
--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -38,5 +38,7 @@ final readonly class MonitoringConfiguration
         public MiddlewareStatusProviderConfiguration $providerConfiguration,
         #[ExtConfProperty(path: 'api.endpoint')]
         public string $endpoint = 'monitor/health',
+        #[ExtConfProperty(path: 'api.enforceHttps')]
+        public bool $enforceHttps = false,
     ) {}
 }

--- a/Classes/Middleware/MonitoringMiddleware.php
+++ b/Classes/Middleware/MonitoringMiddleware.php
@@ -28,6 +28,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 
 /**
  * MonitoringMiddleware.
@@ -60,7 +61,7 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        if (!$this->isHttps($request)) {
+        if ($this->monitoringConfiguration->enforceHttps && !$this->isHttps($request)) {
             try {
                 return $this->jsonResponse(
                     [
@@ -114,12 +115,17 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
 
     private function isHttps(ServerRequestInterface $request): bool
     {
+        $normalizedParams = $request->getAttribute('normalizedParams');
+
+        if ($normalizedParams instanceof NormalizedParams) {
+            return $normalizedParams->isHttps();
+        }
+
         return $request->getUri()->getScheme() === 'https';
     }
 
     /**
      * Checks if request is authorized by any of the registered authorizers. First one take the win.
-     *
      */
     private function isAuthorized(ServerRequestInterface $request): bool
     {

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -61,6 +61,11 @@ Access while logged in as TYPO3 backend administrator.
 }
 ```
 
+> Only returned when `api.enforceHttps` is enabled. By default the extension
+> does not enforce HTTPS in PHP — TLS termination is expected to happen at the
+> web server / ingress. See [Configuration](configuration.md) for details and
+> the trusted-proxy caveats.
+
 ## Status Codes
 
 | Code | Meaning             | Description                        |

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -9,6 +9,7 @@ return [
         'monitoring' => [
             'api' => [
                 'endpoint' => '/monitor/health',
+                'enforceHttps' => false,
             ],
             'authorizer' => [
                 'mteu\Monitoring\Authorization\TokenAuthorizer' => [
@@ -37,6 +38,14 @@ return [
 
 ### API
 - **`endpoint`**: URL path for monitoring endpoint (default: `/monitor/health`)
+- **`enforceHttps`**: Reject monitoring requests that are not HTTPS (default: `false`).
+  TLS termination should happen at the web server / ingress, not in PHP — leave
+  this off unless you have a specific reason to enable it. When enabled, the
+  middleware uses TYPO3's `NormalizedParams::isHttps()`, which honors the
+  trusted-proxy configuration in `$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']`
+  and `reverseProxySSL`. Make sure those are configured correctly first;
+  otherwise legitimate requests behind a reverse proxy will be rejected with a
+  `403 unsupported-protocol` response.
 
 ### Token Authorizer
 - **`enabled`**: Enable token authentication (default: `false`)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ The monitoring endpoint returns JSON with the following structure:
 HTTP status codes:
 - `200` All services healthy
 - `401` Unauthorized access
-- `403` Unsupported protocol
+- `403` Unsupported protocol (only when `api.enforceHttps` is enabled — see
+  [Configuration](Documentation/configuration.md); TLS is best terminated at
+  the web server / ingress, so this check is opt-in)
 - `503` One or more services unhealthy
 
 ## 🧑‍💻 Development

--- a/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
@@ -33,6 +33,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ResponseFactory;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
@@ -115,9 +116,9 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function returns403ResponseForNonHttpsRequests(): void
+    public function returns403ResponseForNonHttpsRequestsWhenEnforced(): void
     {
-        $configuration = $this->createConfiguration('/health');
+        $configuration = $this->createConfiguration('/health', enforceHttps: true);
         $provider = $this->createHealthyProvider();
         $authorizer = $this->createAuthorizedAuthorizer();
 
@@ -137,6 +138,55 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
 
         self::assertInstanceOf(ResponseInterface::class, $result);
         self::assertSame(403, $result->getStatusCode());
+    }
+
+    #[Test]
+    public function allowsPlainHttpRequestWhenEnforceHttpsIsDisabled(): void
+    {
+        $configuration = $this->createConfiguration('/health');
+        $provider = $this->createHealthyProvider();
+        $authorizer = $this->createAuthorizedAuthorizer();
+
+        $middleware = new MonitoringMiddleware(
+            [$provider],
+            [$authorizer],
+            $configuration,
+            $this->responseFactory,
+            $this->logger
+        );
+
+        $request = $this->createHttpRequest('/health');
+
+        $this->handler->expects(self::never())->method('handle');
+
+        $result = $middleware->process($request, $this->handler);
+
+        self::assertSame(200, $result->getStatusCode());
+    }
+
+    #[Test]
+    public function acceptsHttpRequestWhenNormalizedParamsReportsHttps(): void
+    {
+        $configuration = $this->createConfiguration('/health', enforceHttps: true);
+        $provider = $this->createHealthyProvider();
+        $authorizer = $this->createAuthorizedAuthorizer();
+
+        $middleware = new MonitoringMiddleware(
+            [$provider],
+            [$authorizer],
+            $configuration,
+            $this->responseFactory,
+            $this->logger
+        );
+
+        $request = $this->createHttpRequest('/health')
+            ->withAttribute('normalizedParams', $this->createNormalizedParams(true));
+
+        $this->handler->expects(self::never())->method('handle');
+
+        $result = $middleware->process($request, $this->handler);
+
+        self::assertSame(200, $result->getStatusCode());
     }
 
     #[Test]
@@ -220,7 +270,7 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
         self::assertSame(503, $result->getStatusCode());
     }
 
-    private function createConfiguration(string $endpoint): MonitoringConfiguration
+    private function createConfiguration(string $endpoint, bool $enforceHttps = false): MonitoringConfiguration
     {
         $tokenAuthorizerConfig = new TokenAuthorizerConfiguration();
         $adminUserAuthorizerConfig = new AdminUserAuthorizerConfiguration();
@@ -230,7 +280,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             $tokenAuthorizerConfig,
             $adminUserAuthorizerConfig,
             $providerConfig,
-            $endpoint
+            $endpoint,
+            $enforceHttps,
         );
     }
 
@@ -334,6 +385,14 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
     {
         $uri = new Uri('http://example.com' . $path);
         return new ServerRequest($uri, 'GET');
+    }
+
+    private function createNormalizedParams(bool $isHttps): NormalizedParams
+    {
+        $normalizedParams = $this->createMock(NormalizedParams::class);
+        $normalizedParams->method('isHttps')->willReturn($isHttps);
+
+        return $normalizedParams;
     }
 
 }

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -35,6 +35,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ResponseFactory;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
@@ -196,6 +197,91 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
 
         // Verify high priority authorizer was called before low priority
         self::assertSame(['high', 'low'], $callOrder);
+    }
+
+    #[Test]
+    public function normalizedParamsHttpsAttributeIsHonoredForReverseProxyRequests(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health', 'enforceHttps' => '1'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $middleware = new MonitoringMiddleware(
+            [$this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+        );
+
+        $request = $this->createRequestMock('/monitor/health', 'http')
+            ->withAttribute('normalizedParams', $this->createNormalizedParamsMock(true));
+
+        $this->handler->expects(self::never())->method('handle');
+
+        $response = $middleware->process($request, $this->handler);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function normalizedParamsHttpsAttributeIsHonoredWhenSchemeIsHttpsButProxyReportsHttp(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health', 'enforceHttps' => '1'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $middleware = new MonitoringMiddleware(
+            [$this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+        );
+
+        $request = $this->createRequestMock('/monitor/health', 'https')
+            ->withAttribute('normalizedParams', $this->createNormalizedParamsMock(false));
+
+        $this->handler->expects(self::never())->method('handle');
+
+        $response = $middleware->process($request, $this->handler);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function plainHttpRequestIsAllowedWhenEnforceHttpsIsDisabled(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health', 'enforceHttps' => '0'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $middleware = new MonitoringMiddleware(
+            [$this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+        );
+
+        $request = $this->createRequestMock('/monitor/health', 'http');
+
+        $this->handler->expects(self::never())->method('handle');
+
+        $response = $middleware->process($request, $this->handler);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function createNormalizedParamsMock(bool $isHttps): NormalizedParams
+    {
+        $normalizedParams = $this->createMock(NormalizedParams::class);
+        $normalizedParams->method('isHttps')->willReturn($isHttps);
+
+        return $normalizedParams;
     }
 
     /**

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,8 @@
 api {
     # cat=api/endpoint; type=string; label=Endpoint Route
     endpoint=/monitor/health
+    # cat=api/enforceHttps; type=boolean; label=Enforce HTTPS:Reject monitoring requests that are not HTTPS. TLS is best terminated at the web server / ingress; only enable this once $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] / 'reverseProxySSL' (trusted proxies) are configured correctly, otherwise legitimate requests behind a proxy will be rejected.
+    enforceHttps=0
 }
 
 authorizer {


### PR DESCRIPTION
The middleware previously read the request scheme straight from the PSR-7 URI, which breaks behind reverse proxies unless reverseProxyIP / reverseProxySSL are configured. That made a correctly TLS-terminated site easy to lock out of its own monitoring.