### PR TITLE
[BUGFIX] Execute provider only once per request

### DIFF
--- a/Classes/Middleware/MonitoringMiddleware.php
+++ b/Classes/Middleware/MonitoringMiddleware.php
@@ -19,6 +19,7 @@ namespace mteu\Monitoring\Middleware;
 
 use mteu\Monitoring\Authorization\Authorizer;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Provider\MiddlewareStatusProvider;
 use mteu\Monitoring\Provider\MonitoringProvider;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -49,6 +50,7 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
         private MonitoringConfiguration $monitoringConfiguration,
         private ResponseFactoryInterface $responseFactory,
         private LoggerInterface $logger,
+        private MonitoringExecutionHandler $executionHandler,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -92,15 +94,18 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
         }
 
         try {
+            $status = $this->getHealthStatus();
+            $isHealthy = !in_array(false, $status, true);
+
             return $this->jsonResponse(
                 [
-                    'isHealthy' => $this->isHealthy(),
+                    'isHealthy' => $isHealthy,
                     'services' => array_map(
                         static fn(bool $serviceStatus): string => $serviceStatus ? 'healthy' : 'unhealthy',
-                        $this->getHealthStatus()
+                        $status
                     ),
                 ],
-                $this->isHealthy() ? 200 : 503,
+                $isHealthy ? 200 : 503,
             );
         } catch (\JsonException $e) {
             $this->logger->error($e->getMessage());
@@ -156,16 +161,11 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
                     continue;
                 }
 
-                $status[$provider->getName()] = $provider->execute()->isHealthy();
+                $status[$provider->getName()] = $this->executionHandler->executeProvider($provider)->isHealthy();
             }
         }
 
         return $status;
-    }
-
-    private function isHealthy(): bool
-    {
-        return !in_array(false, $this->getHealthStatus(), true);
     }
 
     /**

--- a/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
@@ -22,6 +22,7 @@ use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
 use mteu\Monitoring\Configuration\Provider\MiddlewareStatusProviderConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Middleware\MonitoringMiddleware;
 use mteu\Monitoring\Provider\MonitoringProvider;
 use mteu\Monitoring\Result\MonitoringResult;
@@ -77,7 +78,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpsRequest('/health');
@@ -102,7 +104,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpsRequest('/health');
@@ -127,7 +130,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpRequest('/health');
@@ -152,7 +156,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpRequest('/health');
@@ -176,7 +181,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpRequest('/health')
@@ -201,7 +207,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpsRequest('/different-path');
@@ -229,7 +236,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpsRequest('/health');
@@ -257,7 +265,8 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
             [$authorizer],
             $configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->get(MonitoringExecutionHandler::class),
         );
 
         $request = $this->createHttpsRequest('/health');

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -18,9 +18,13 @@ declare(strict_types=1);
 namespace mteu\Monitoring\Tests\Unit\Middleware;
 
 use mteu\Monitoring\Authorization\Authorizer;
+use mteu\Monitoring\Cache\MonitoringCacheManager;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Middleware\MonitoringMiddleware;
+use mteu\Monitoring\Provider\CacheableMonitoringProvider;
 use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Result\CachedMonitoringResult;
 use mteu\Monitoring\Result\MonitoringResult;
 use mteu\Monitoring\Result\Result;
 use mteu\TypedExtConf\Mapper\TreeMapperFactory;
@@ -34,6 +38,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ResponseFactory;
@@ -87,7 +94,8 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $shouldCreateResponse ? [$authorizer] : [],
             $this->configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $request = $this->createRequestMock('/monitor/health', 'https');
@@ -127,6 +135,7 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $this->configuration,
             $this->responseFactory,
             $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $this->handler->expects(self::never())->method('handle');
@@ -158,6 +167,7 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $this->configuration,
             $this->responseFactory,
             $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $response = $middleware->process(
@@ -188,7 +198,8 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             [$highPriorityAuthorizer, $lowPriorityAuthorizer], // High priority should come first in DI
             $this->configuration,
             $this->responseFactory,
-            $this->logger
+            $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $request = $this->createRequestMock('/monitor/health', 'https');
@@ -213,6 +224,7 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $this->configuration,
             $this->responseFactory,
             $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $request = $this->createRequestMock('/monitor/health', 'http')
@@ -239,6 +251,7 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $this->configuration,
             $this->responseFactory,
             $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $request = $this->createRequestMock('/monitor/health', 'https')
@@ -265,6 +278,7 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             $this->configuration,
             $this->responseFactory,
             $this->logger,
+            $this->createExecutionHandler(),
         );
 
         $request = $this->createRequestMock('/monitor/health', 'http');
@@ -274,6 +288,143 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
         $response = $middleware->process($request, $this->handler);
 
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function createExecutionHandler(?MonitoringCacheManager $cacheManager = null): MonitoringExecutionHandler
+    {
+        if ($cacheManager === null) {
+            $typo3CacheManager = $this->createMock(CacheManager::class);
+            $typo3CacheManager->method('getCache')
+                ->willThrowException(new NoSuchCacheException('no cache in unit tests', 1234567890));
+            $cacheManager = new MonitoringCacheManager($typo3CacheManager);
+        }
+
+        return new MonitoringExecutionHandler($cacheManager);
+    }
+
+    #[Test]
+    public function providerIsExecutedOnlyOncePerRequest(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $provider = new class () implements MonitoringProvider {
+            private int $executionCount = 0;
+            public function getName(): string
+            {
+                return 'counted';
+            }
+            public function getDescription(): string
+            {
+                return 'Counts how often execute() is called.';
+            }
+            public function isActive(): bool
+            {
+                return true;
+            }
+            public function execute(): Result
+            {
+                $this->executionCount++;
+                return new MonitoringResult('counted', true);
+            }
+            public function getExecutionCount(): int
+            {
+                return $this->executionCount;
+            }
+        };
+
+        $middleware = new MonitoringMiddleware(
+            [$provider],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler(),
+        );
+
+        $middleware->process($this->createRequestMock('/monitor/health', 'https'), $this->handler);
+
+        self::assertSame(1, $provider->getExecutionCount());
+    }
+
+    #[Test]
+    public function cacheableProviderIsRoutedThroughCacheManager(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $cacheableProvider = new class () implements CacheableMonitoringProvider {
+            private int $executionCount = 0;
+            public function getName(): string
+            {
+                return 'cacheable';
+            }
+            public function getDescription(): string
+            {
+                return 'Cacheable provider used to verify cache routing.';
+            }
+            public function isActive(): bool
+            {
+                return true;
+            }
+            public function execute(): Result
+            {
+                $this->executionCount++;
+                return new MonitoringResult('cacheable', true);
+            }
+            public function getCacheKey(): string
+            {
+                return 'cacheable-key';
+            }
+            public function getCacheLifetime(): int
+            {
+                return 60;
+            }
+            public function getExecutionCount(): int
+            {
+                return $this->executionCount;
+            }
+        };
+
+        $cachedResult = new CachedMonitoringResult(
+            new MonitoringResult('cacheable', true),
+            new \DateTimeImmutable('now'),
+            60,
+        );
+
+        $frontend = $this->createMock(FrontendInterface::class);
+        $frontend->method('has')->with('cacheable-key')->willReturn(true);
+        $frontend->expects(self::once())
+            ->method('get')
+            ->with('cacheable-key')
+            ->willReturn($cachedResult);
+        $frontend->expects(self::never())->method('set');
+
+        $typo3CacheManager = $this->createMock(CacheManager::class);
+        $typo3CacheManager->method('getCache')->willReturn($frontend);
+
+        $cacheManager = new MonitoringCacheManager($typo3CacheManager);
+
+        $middleware = new MonitoringMiddleware(
+            [$cacheableProvider],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler($cacheManager),
+        );
+
+        $response = $middleware->process(
+            $this->createRequestMock('/monitor/health', 'https'),
+            $this->handler,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(0, $cacheableProvider->getExecutionCount(), 'Cached provider must not re-execute when cache is warm');
     }
 
     private function createNormalizedParamsMock(bool $isHttps): NormalizedParams


### PR DESCRIPTION
`MonitoringMiddleware::process()` previously called `isHealthy()` and `getHealthStatus()` separately, and `isHealthy()` itself re-ran the full status collection. Every active provider's `execute()` therefore ran three times per request, and the middleware bypassed the cache layer entirely — so `CacheableMonitoringProvider` instances paid the full cost two-three times.
