### PR TITLE
[!!!][TASK] Flush cache by POST request instead of GET

### DIFF
--- a/Classes/Backend/Controller/FlushProviderCacheController.php
+++ b/Classes/Backend/Controller/FlushProviderCacheController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Backend\Controller;
+
+use mteu\Monitoring\Cache\MonitoringCacheManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
+use TYPO3\CMS\Core\Http\AllowedMethodsTrait;
+use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+
+/**
+ * FlushProviderCacheController.
+ *
+ * Dedicated POST endpoint for flushing a single monitoring provider's cache. Validates a
+ * backend form-protection token bound to the provider class before mutating state, so
+ * cross-site requests can't trigger a flush against an authenticated backend session.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[AsController]
+final readonly class FlushProviderCacheController
+{
+    use AllowedMethodsTrait;
+
+    public const string CSRF_TOKEN_FORM_NAME = 'tx_monitoring_flush_provider_cache';
+    public const string CSRF_TOKEN_ACTION = 'flushProviderCache';
+
+    private const string LOCALLANG_FILE = 'LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf';
+    private const string FLASHMESSAGE_QUEUE_IDENTIFIER = 'ext_monitoring_message_queue';
+
+    public function __construct(
+        private MonitoringCacheManager $cacheManager,
+        private FlashMessageService $flashMessageService,
+        private LanguageServiceFactory $languageServiceFactory,
+        private UriBuilder $uriBuilder,
+        private FormProtectionFactory $formProtectionFactory,
+    ) {}
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws RouteNotFoundException
+     */
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->assertAllowedHttpMethod($request, 'POST');
+
+        $parsedBody = $request->getParsedBody();
+        $parsedBody = is_array($parsedBody) ? $parsedBody : [];
+        $providerClass = is_string($parsedBody['providerClass'] ?? null) ? $parsedBody['providerClass'] : '';
+        $token = is_string($parsedBody['formToken'] ?? null) ? $parsedBody['formToken'] : '';
+
+        $languageService = $this->getLanguageService();
+        $messageQueue = $this->flashMessageService->getMessageQueueByIdentifier(self::FLASHMESSAGE_QUEUE_IDENTIFIER);
+        $redirectUri = $this->uriBuilder->buildUriFromRoute('monitoring');
+
+        $formProtection = $this->formProtectionFactory->createFromRequest($request);
+
+        if ($providerClass === '' || !$formProtection->validateToken($token, self::CSRF_TOKEN_FORM_NAME, self::CSRF_TOKEN_ACTION, $providerClass)) {
+            $messageQueue->addMessage(new FlashMessage(
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.message'),
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.title'),
+                ContextualFeedbackSeverity::ERROR,
+            ));
+
+            return new RedirectResponse($redirectUri);
+        }
+
+        if ($this->cacheManager->flushProviderCache($providerClass)) {
+            $message = new FlashMessage(
+                sprintf(
+                    $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.success.message'),
+                    $providerClass,
+                ),
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.success.title'),
+                ContextualFeedbackSeverity::OK,
+            );
+        } else {
+            $message = new FlashMessage(
+                sprintf(
+                    $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.error.message'),
+                    $providerClass,
+                ),
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.error.title'),
+                ContextualFeedbackSeverity::ERROR,
+            );
+        }
+
+        $messageQueue->addMessage($message);
+
+        return new RedirectResponse($redirectUri);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+
+        if ($backendUser instanceof BackendUserAuthentication) {
+            return $this->languageServiceFactory->createFromUserPreferences($backendUser);
+        }
+
+        return $this->languageServiceFactory->createFromUserPreferences(null);
+    }
+}

--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -29,21 +29,13 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use TYPO3\CMS\Backend\Attribute\AsController;
-use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
 use TYPO3\CMS\Core\Http\AllowedMethodsTrait;
 use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
 use TYPO3\CMS\Core\Http\NormalizedParams;
-use TYPO3\CMS\Core\Http\RedirectResponse;
-use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
-use TYPO3\CMS\Core\Messaging\FlashMessage;
-use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 
 /**
  * MonitoringController.
@@ -56,10 +48,7 @@ final readonly class MonitoringController
 {
     use AllowedMethodsTrait;
 
-    private const string LOCALLANG_FILE = 'LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf';
     private const string FLASHMESSAGE_QUEUE_IDENTIFIER = 'ext_monitoring_message_queue';
-    private const string CSRF_TOKEN_FORM_NAME = 'tx_monitoring_flush_provider_cache';
-    private const string CSRF_TOKEN_ACTION = 'flushProviderCache';
 
     public function __construct(
         /** @var MonitoringProvider[] $monitoringProviders */
@@ -70,8 +59,6 @@ final readonly class MonitoringController
         #[AutowireIterator(tag: 'monitoring.authorizer', defaultPriorityMethod: 'getPriority')]
         private iterable $authorizers,
         private ModuleTemplateFactory $moduleTemplateFactory,
-        private FlashMessageService $flashMessageService,
-        private LanguageServiceFactory $languageServiceFactory,
         private MonitoringExecutionHandler $executionHandler,
         private MonitoringCacheManager $cacheManager,
         private MonitoringConfiguration $monitoringConfiguration,
@@ -148,76 +135,6 @@ final readonly class MonitoringController
     }
 
     /**
-     * Handle flush cache action with flash messages and redirect.
-     *
-     * Wired to a POST-only route (`monitoring_flush_provider_cache`) and
-     * protected with a backend form token to mitigate CSRF.
-     *
-     * @throws MethodNotAllowedException
-     * @throws RouteNotFoundException
-     */
-    public function flushProviderCache(ServerRequestInterface $request): ResponseInterface
-    {
-        $this->assertAllowedHttpMethod($request, 'POST');
-
-        $parsedBody = $request->getParsedBody();
-        $parsedBody = is_array($parsedBody) ? $parsedBody : [];
-        $providerClass = is_string($parsedBody['providerClass'] ?? null) ? $parsedBody['providerClass'] : '';
-        $token = is_string($parsedBody['formToken'] ?? null) ? $parsedBody['formToken'] : '';
-
-        $languageService = $this->getLanguageService();
-        $messageQueue = $this->flashMessageService->getMessageQueueByIdentifier(self::FLASHMESSAGE_QUEUE_IDENTIFIER);
-        $redirectUri = $this->uriBuilder->buildUriFromRoute('monitoring');
-
-        $formProtection = $this->formProtectionFactory->createFromRequest($request);
-
-        if ($providerClass === '' || !$formProtection->validateToken($token, self::CSRF_TOKEN_FORM_NAME, self::CSRF_TOKEN_ACTION, $providerClass)) {
-            $messageQueue->addMessage(new FlashMessage(
-                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.message'),
-                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.title'),
-                ContextualFeedbackSeverity::ERROR,
-            ));
-
-            return new RedirectResponse($redirectUri);
-        }
-
-        if ($this->cacheManager->flushProviderCache($providerClass)) {
-            $message = new FlashMessage(
-                sprintf(
-                    $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.success.message'),
-                    $providerClass,
-                ),
-                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.success.title'),
-                ContextualFeedbackSeverity::OK,
-            );
-        } else {
-            $message = new FlashMessage(
-                sprintf(
-                    $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.error.message'),
-                    $providerClass,
-                ),
-                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.error.title'),
-                ContextualFeedbackSeverity::ERROR,
-            );
-        }
-
-        $messageQueue->addMessage($message);
-
-        return new RedirectResponse($redirectUri);
-    }
-
-    private function getLanguageService(): LanguageService
-    {
-        $backendUser = $GLOBALS['BE_USER'] ?? null;
-
-        if ($backendUser instanceof BackendUserAuthentication) {
-            return $this->languageServiceFactory->createFromUserPreferences($backendUser);
-        }
-
-        return $this->languageServiceFactory->createFromUserPreferences(null);
-    }
-
-    /**
      * Build template variables for all monitoring providers
      *
      * @return array<class-string<\mteu\Monitoring\Provider\MonitoringProvider>, array{
@@ -257,8 +174,8 @@ final readonly class MonitoringController
             if ($monitoringProvider instanceof CacheableMonitoringProvider) {
                 $providerTemplateVariables[$monitoringProvider::class]['cacheLifetime'] = $monitoringProvider->getCacheLifetime();
                 $providerTemplateVariables[$monitoringProvider::class]['flushToken'] = $formProtection->generateToken(
-                    self::CSRF_TOKEN_FORM_NAME,
-                    self::CSRF_TOKEN_ACTION,
+                    FlushProviderCacheController::CSRF_TOKEN_FORM_NAME,
+                    FlushProviderCacheController::CSRF_TOKEN_ACTION,
                     $monitoringProvider::class,
                 );
             }

--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Crypto\HashService;
+use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
 use TYPO3\CMS\Core\Http\AllowedMethodsTrait;
 use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
 use TYPO3\CMS\Core\Http\NormalizedParams;
@@ -57,6 +58,8 @@ final readonly class MonitoringController
 
     private const string LOCALLANG_FILE = 'LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf';
     private const string FLASHMESSAGE_QUEUE_IDENTIFIER = 'ext_monitoring_message_queue';
+    private const string CSRF_TOKEN_FORM_NAME = 'tx_monitoring_flush_provider_cache';
+    private const string CSRF_TOKEN_ACTION = 'flushProviderCache';
 
     public function __construct(
         /** @var MonitoringProvider[] $monitoringProviders */
@@ -74,6 +77,7 @@ final readonly class MonitoringController
         private MonitoringConfiguration $monitoringConfiguration,
         private UriBuilder $uriBuilder,
         private HashService $hashService,
+        private FormProtectionFactory $formProtectionFactory,
     ) {}
 
     /**
@@ -82,16 +86,6 @@ final readonly class MonitoringController
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         $this->assertAllowedHttpMethod($request, 'GET');
-
-        // Handle flush action if present
-        $action = $request->getQueryParams()['action'] ?? '';
-
-        /** @var string $providerClass */
-        $providerClass = $request->getQueryParams()['providerClass'] ?? '';
-
-        if ($action === 'flushProviderCache' && $providerClass !== '') {
-            return $this->handleFlushProviderCache($providerClass, $request);
-        }
 
         $template = $this->moduleTemplateFactory->create($request);
 
@@ -105,9 +99,10 @@ final readonly class MonitoringController
             'middlewareStatusResult' => $this->executionHandler->executeProvider(
                 $this->getMiddlewareStatusProvider(),
             ),
-            'providers' => $this->buildProviderTemplateVariables(),
+            'providers' => $this->buildProviderTemplateVariables($request),
             'providerInterface' => MonitoringProvider::class,
             'monitoringMessageQueueIdentifier' => self::FLASHMESSAGE_QUEUE_IDENTIFIER,
+            'flushProviderCacheUri' => (string)$this->uriBuilder->buildUriFromRoute('monitoring_flush_provider_cache'),
         ];
 
         return $template
@@ -153,13 +148,38 @@ final readonly class MonitoringController
     }
 
     /**
-     * Handle flush cache action with flash messages and redirect
+     * Handle flush cache action with flash messages and redirect.
+     *
+     * Wired to a POST-only route (`monitoring_flush_provider_cache`) and
+     * protected with a backend form token to mitigate CSRF.
+     *
+     * @throws MethodNotAllowedException
      * @throws RouteNotFoundException
      */
-    private function handleFlushProviderCache(string $providerClass, ServerRequestInterface $request): ResponseInterface
+    public function flushProviderCache(ServerRequestInterface $request): ResponseInterface
     {
+        $this->assertAllowedHttpMethod($request, 'POST');
+
+        $parsedBody = $request->getParsedBody();
+        $parsedBody = is_array($parsedBody) ? $parsedBody : [];
+        $providerClass = is_string($parsedBody['providerClass'] ?? null) ? $parsedBody['providerClass'] : '';
+        $token = is_string($parsedBody['formToken'] ?? null) ? $parsedBody['formToken'] : '';
+
         $languageService = $this->getLanguageService();
         $messageQueue = $this->flashMessageService->getMessageQueueByIdentifier(self::FLASHMESSAGE_QUEUE_IDENTIFIER);
+        $redirectUri = $this->uriBuilder->buildUriFromRoute('monitoring');
+
+        $formProtection = $this->formProtectionFactory->createFromRequest($request);
+
+        if ($providerClass === '' || !$formProtection->validateToken($token, self::CSRF_TOKEN_FORM_NAME, self::CSRF_TOKEN_ACTION, $providerClass)) {
+            $messageQueue->addMessage(new FlashMessage(
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.message'),
+                $languageService->sL(self::LOCALLANG_FILE . ':provider.cache.flush.csrf.title'),
+                ContextualFeedbackSeverity::ERROR,
+            ));
+
+            return new RedirectResponse($redirectUri);
+        }
 
         if ($this->cacheManager->flushProviderCache($providerClass)) {
             $message = new FlashMessage(
@@ -183,9 +203,7 @@ final readonly class MonitoringController
 
         $messageQueue->addMessage($message);
 
-        return new RedirectResponse(
-            $this->uriBuilder->buildUriFromRequest($request),
-        );
+        return new RedirectResponse($redirectUri);
     }
 
     private function getLanguageService(): LanguageService
@@ -210,11 +228,13 @@ final readonly class MonitoringController
      *     description: string,
      *     cacheLifetime?: int,
      *     subResults?: array<\mteu\Monitoring\Result\Result>,
-     *     cacheExpiresAt?: \DateTimeImmutable
+     *     cacheExpiresAt?: \DateTimeImmutable,
+     *     flushToken?: string
      * }>
      */
-    private function buildProviderTemplateVariables(): array
+    private function buildProviderTemplateVariables(ServerRequestInterface $request): array
     {
+        $formProtection = $this->formProtectionFactory->createFromRequest($request);
         $providerTemplateVariables = [];
 
         foreach ($this->monitoringProviders as $monitoringProvider) {
@@ -236,6 +256,11 @@ final readonly class MonitoringController
 
             if ($monitoringProvider instanceof CacheableMonitoringProvider) {
                 $providerTemplateVariables[$monitoringProvider::class]['cacheLifetime'] = $monitoringProvider->getCacheLifetime();
+                $providerTemplateVariables[$monitoringProvider::class]['flushToken'] = $formProtection->generateToken(
+                    self::CSRF_TOKEN_FORM_NAME,
+                    self::CSRF_TOKEN_ACTION,
+                    $monitoringProvider::class,
+                );
             }
 
             if ($result->hasSubResults()) {

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -22,6 +22,7 @@ return [
     ],
     'monitoring_flush_provider_cache' => [
         'path' => '/monitoring/flush-provider-cache',
+        'methods' => ['POST'],
         'target' => \mteu\Monitoring\Backend\Controller\MonitoringController::class . '::flushProviderCache',
     ],
 ];

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -23,6 +23,6 @@ return [
     'monitoring_flush_provider_cache' => [
         'path' => '/monitoring/flush-provider-cache',
         'methods' => ['POST'],
-        'target' => \mteu\Monitoring\Backend\Controller\MonitoringController::class . '::flushProviderCache',
+        'target' => \mteu\Monitoring\Backend\Controller\FlushProviderCacheController::class,
     ],
 ];

--- a/Resources/Private/Language/locallang.be.xlf
+++ b/Resources/Private/Language/locallang.be.xlf
@@ -102,6 +102,12 @@
 			<trans-unit id="provider.cache.flush.error.message">
 				<source>Failed to flush cache for provider "%s".</source>
 			</trans-unit>
+			<trans-unit id="provider.cache.flush.csrf.title">
+				<source>Cache Flush Rejected</source>
+			</trans-unit>
+			<trans-unit id="provider.cache.flush.csrf.message">
+				<source>The cache flush request could not be verified. Please retry from the monitoring module.</source>
+			</trans-unit>
 			<trans-unit id="api.error.title">
 				<source>API Error</source>
 			</trans-unit>

--- a/Resources/Private/Partials/Backend/Provider/Item.html
+++ b/Resources/Private/Partials/Backend/Provider/Item.html
@@ -77,11 +77,15 @@
             </p>
         </div>
         <div class="card-footer">
-            <f:link.page additionalParams="{action: 'flushProviderCache', providerClass: class, class: 'btn btn-default'}">
-                <span class="text-primary inside">
-                    <f:translate key="LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf:provider.cache.flush.button" />
-                </span>
-            </f:link.page>
+            <form method="post" action="{flushProviderCacheUri}">
+                <input type="hidden" name="providerClass" value="{class}" />
+                <input type="hidden" name="formToken" value="{provider.flushToken}" />
+                <button type="submit" class="btn btn-default">
+                    <span class="text-primary inside">
+                        <f:translate key="LLL:EXT:monitoring/Resources/Private/Language/locallang.be.xlf:provider.cache.flush.button" />
+                    </span>
+                </button>
+            </form>
         </div>
     </div>
 

--- a/Resources/Private/Templates/Backend/Monitoring.html
+++ b/Resources/Private/Templates/Backend/Monitoring.html
@@ -30,7 +30,7 @@
 
     <f:if condition="{providers}">
         <f:then>
-            <f:render partial="Backend/Provider/List" arguments="{providers: providers, providerInterface: providerInterface}" />
+            <f:render partial="Backend/Provider/List" arguments="{providers: providers, providerInterface: providerInterface, flushProviderCacheUri: flushProviderCacheUri}" />
         </f:then>
         <f:else>
             <div class="alert alert-info">

--- a/Tests/Unit/Backend/Controller/FlushProviderCacheControllerTest.php
+++ b/Tests/Unit/Backend/Controller/FlushProviderCacheControllerTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Backend\Controller;
+
+use mteu\Monitoring\Backend\Controller\FlushProviderCacheController;
+use mteu\Monitoring\Cache\MonitoringCacheManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\FormProtection\AbstractFormProtection;
+use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
+use TYPO3\CMS\Core\Http\Error\MethodNotAllowedException;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+
+/**
+ * FlushProviderCacheControllerTest.
+ *
+ * Covers the security-relevant orchestration: which flash message variant is queued under
+ * each branch, and that the cache is never mutated unless POST + a valid backend
+ * form-protection token bound to the requested provider class are both present.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(FlushProviderCacheController::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class FlushProviderCacheControllerTest extends TestCase
+{
+    private CacheManager&MockObject $coreCacheManager;
+    private FlashMessageQueue&MockObject $flashMessageQueue;
+    private FlashMessageService&Stub $flashMessageService;
+    private LanguageServiceFactory&Stub $languageServiceFactory;
+    private UriBuilder&Stub $uriBuilder;
+    private AbstractFormProtection&Stub $formProtection;
+    private FormProtectionFactory&Stub $formProtectionFactory;
+
+    protected function setUp(): void
+    {
+        $this->coreCacheManager = $this->createMock(CacheManager::class);
+        $this->flashMessageQueue = $this->createMock(FlashMessageQueue::class);
+
+        $this->flashMessageService = self::createStub(FlashMessageService::class);
+        $this->flashMessageService
+            ->method('getMessageQueueByIdentifier')
+            ->willReturn($this->flashMessageQueue);
+
+        $languageService = self::createStub(LanguageService::class);
+        // Echo the LLL key so flash assertions can match on it.
+        $languageService->method('sL')->willReturnArgument(0);
+        $this->languageServiceFactory = self::createStub(LanguageServiceFactory::class);
+        $this->languageServiceFactory->method('createFromUserPreferences')->willReturn($languageService);
+
+        $uri = self::createStub(UriInterface::class);
+        $uri->method('__toString')->willReturn('/typo3/module/site/monitoring');
+        $this->uriBuilder = self::createStub(UriBuilder::class);
+        $this->uriBuilder->method('buildUriFromRoute')->willReturn($uri);
+
+        $this->formProtection = self::createStub(AbstractFormProtection::class);
+        $this->formProtectionFactory = self::createStub(FormProtectionFactory::class);
+        $this->formProtectionFactory->method('createFromRequest')->willReturn($this->formProtection);
+
+        $GLOBALS['BE_USER'] = null;
+    }
+
+    private function createController(): FlushProviderCacheController
+    {
+        return new FlushProviderCacheController(
+            cacheManager: new MonitoringCacheManager($this->coreCacheManager),
+            flashMessageService: $this->flashMessageService,
+            languageServiceFactory: $this->languageServiceFactory,
+            uriBuilder: $this->uriBuilder,
+            formProtectionFactory: $this->formProtectionFactory,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function createPostRequest(array $body): ServerRequestInterface
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('POST');
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+
+    #[Test]
+    public function rejectsNonPostWithMethodNotAllowed(): void
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('GET');
+
+        $this->coreCacheManager->expects(self::never())->method('getCache');
+
+        $this->expectException(MethodNotAllowedException::class);
+        ($this->createController())($request);
+    }
+
+    #[Test]
+    public function rejectsInvalidCsrfTokenWithoutTouchingCache(): void
+    {
+        $this->formProtection->method('validateToken')->willReturn(false);
+
+        $this->coreCacheManager->expects(self::never())->method('getCache');
+        $this->flashMessageQueue
+            ->expects(self::once())
+            ->method('addMessage')
+            ->with(self::callback(static fn(FlashMessage $m): bool =>
+                $m->getSeverity() === ContextualFeedbackSeverity::ERROR
+                && str_contains($m->getTitle(), 'flush.csrf')));
+
+        $response = ($this->createController())(
+            $this->createPostRequest([
+                'providerClass' => 'Vendor\\SomeProvider',
+                'formToken' => 'tampered',
+            ]),
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    #[Test]
+    public function shortCircuitsOnEmptyProviderClassEvenIfTokenWouldValidate(): void
+    {
+        // Even if the form-protection mock would happily validate, an empty providerClass
+        // must take the CSRF rejection branch and never reach the cache. Guards against
+        // a future "cleanup" that drops the providerClass === '' check.
+        $this->formProtection->method('validateToken')->willReturn(true);
+
+        $this->coreCacheManager->expects(self::never())->method('getCache');
+        $this->flashMessageQueue
+            ->expects(self::once())
+            ->method('addMessage')
+            ->with(self::callback(static fn(FlashMessage $m): bool =>
+                $m->getSeverity() === ContextualFeedbackSeverity::ERROR
+                && str_contains($m->getTitle(), 'flush.csrf')));
+
+        ($this->createController())(
+            $this->createPostRequest([
+                'providerClass' => '',
+                'formToken' => 'whatever',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function reportsSuccessWhenCacheManagerSucceeds(): void
+    {
+        $this->formProtection->method('validateToken')->willReturn(true);
+
+        $cacheFrontend = $this->createMock(FrontendInterface::class);
+        $cacheFrontend
+            ->expects(self::once())
+            ->method('flushByTags')
+            ->with(['Vendor_SomeProvider']);
+        $this->coreCacheManager->method('getCache')->willReturn($cacheFrontend);
+
+        $this->flashMessageQueue
+            ->expects(self::once())
+            ->method('addMessage')
+            ->with(self::callback(static fn(FlashMessage $m): bool =>
+                $m->getSeverity() === ContextualFeedbackSeverity::OK
+                && str_contains($m->getTitle(), 'flush.success')));
+
+        ($this->createController())(
+            $this->createPostRequest([
+                'providerClass' => 'Vendor\\SomeProvider',
+                'formToken' => 'valid',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function reportsFlushFailureWithErrorFlashDistinctFromCsrf(): void
+    {
+        $this->formProtection->method('validateToken')->willReturn(true);
+
+        // Force the underlying flush to fail by making getCache() throw the documented exception.
+        $this->coreCacheManager
+            ->method('getCache')
+            ->willThrowException(new NoSuchCacheException('no cache', 1));
+
+        $this->flashMessageQueue
+            ->expects(self::once())
+            ->method('addMessage')
+            ->with(self::callback(static fn(FlashMessage $m): bool =>
+                $m->getSeverity() === ContextualFeedbackSeverity::ERROR
+                && str_contains($m->getTitle(), 'flush.error')
+                && !str_contains($m->getTitle(), 'flush.csrf')));
+
+        ($this->createController())(
+            $this->createPostRequest([
+                'providerClass' => 'Vendor\\SomeProvider',
+                'formToken' => 'valid',
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
`MonitoringController::__invoke()` was registered as a GET-only handler but performed a state-changing cache flush whenever `?action=flushProviderCache&providerClass=…` was present.

The existing `monitoring_flush_provider_cache` route also pointed at a `flushProviderCache` method that did not exist on the controller, so hitting that path failed to dispatch. 