### PR TITLE
[BUGFIX] Run monitoring command through cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 /.build
-/config
-/var
-/tailor-version-artefact
-
-/.phpunit.result.cache
 /.php-cs-fixer.cache
+/.phpunit.result.cache
+/config
+/fileadmin
+/packages
+/tailor-version-artefact
+/var
+/.ddev
+!/.ddev/config.yaml

--- a/Classes/Command/MonitoringCommand.php
+++ b/Classes/Command/MonitoringCommand.php
@@ -17,12 +17,13 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Command;
 
-use mteu\Monitoring\Provider\CacheableMonitoringProvider;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Handler\ProviderExecutionOutcome;
 use mteu\Monitoring\Provider\MonitoringProvider;
-use mteu\Monitoring\Result\Result;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
@@ -39,6 +40,7 @@ final class MonitoringCommand extends Command
         /** @var iterable<MonitoringProvider> $monitoringProviders */
         #[AutowireIterator(tag: 'monitoring.provider')]
         private readonly iterable $monitoringProviders,
+        private readonly MonitoringExecutionHandler $executionHandler,
     ) {
         parent::__construct(name: 'monitoring:run');
     }
@@ -47,72 +49,73 @@ final class MonitoringCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('This command runs monitoring.');
-
-        // todo: ./vendor/bin typo3 monitoring:run all --no-cache
+        $this->addOption(
+            'no-cache',
+            null,
+            InputOption::VALUE_NONE,
+            'Bypass the monitoring cache and force a fresh execution of every provider.',
+        );
     }
 
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $activeProvidersResult = $this->getActiveProvidersResult();
+        $useCache = $input->getOption('no-cache') === false;
+        $outcomes = $this->executeActiveProviders($useCache);
 
-        if (count($activeProvidersResult) === 0) {
+        if (count($outcomes) === 0) {
             $output->writeln('No active providers available. Skipping.');
 
             return Command::INVALID;
         }
 
         $output->writeln('Checking Monitoring status');
-        foreach ($activeProvidersResult as $providerClass => $result) {
+        foreach ($outcomes as $outcome) {
+            $result = $outcome->result;
             $output->writeln(sprintf(
                 '%s %s%s',
                 $result->isHealthy() ? ' ✅' : '🚨',
                 $result->isHealthy() ? '<info>' . $result->getName() . '</info>' : '<error>' . $result->getName() . '</error>',
-                $this->isCacheableProvider($providerClass) ? ' (cached)' : '',
+                $outcome->fromCache ? ' (cached)' : '',
             ));
         }
 
-        $isHealthy = $this->areAllResultsHealthy($activeProvidersResult);
+        $isHealthy = $this->areAllOutcomesHealthy($outcomes);
         $output->writeln('Monitoring status: ' . ($isHealthy ? 'OK' : 'FAILED'));
 
         return $isHealthy ? Command::SUCCESS : Command::FAILURE;
     }
 
     /**
-     * @return array<class-string<MonitoringProvider>, Result>
+     * @return array<class-string<MonitoringProvider>, ProviderExecutionOutcome>
      */
-    private function getActiveProvidersResult(): array
+    private function executeActiveProviders(bool $useCache): array
     {
-        $status = [];
+        $outcomes = [];
 
         foreach ($this->monitoringProviders as $provider) {
             if ($provider->isActive()) {
-                $status[$provider::class] = $provider->execute();
+                $outcomes[$provider::class] = $this->executionHandler->executeProviderWithMetadata(
+                    $provider,
+                    $useCache,
+                );
             }
         }
 
-        return $status;
+        return $outcomes;
     }
 
     /**
-    * @param array<class-string<MonitoringProvider>, Result> $results
+    * @param array<class-string<MonitoringProvider>, ProviderExecutionOutcome> $outcomes
     */
-    private function areAllResultsHealthy(array $results): bool
+    private function areAllOutcomesHealthy(array $outcomes): bool
     {
-        foreach ($results as $result) {
-            if (!$result->isHealthy()) {
+        foreach ($outcomes as $outcome) {
+            if (!$outcome->result->isHealthy()) {
                 return false;
             }
         }
 
         return true;
-    }
-
-    /**
-     * @param class-string<MonitoringProvider> $providerClass
-     */
-    private function isCacheableProvider(string $providerClass): bool
-    {
-        return is_subclass_of($providerClass, CacheableMonitoringProvider::class);
     }
 }

--- a/Classes/Handler/MonitoringExecutionHandler.php
+++ b/Classes/Handler/MonitoringExecutionHandler.php
@@ -24,7 +24,6 @@ use mteu\Monitoring\Result\Result;
 
 /**
  * MonitoringExecutionHandler.
- * Handles execution of monitoring providers with caching support.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
@@ -36,28 +35,40 @@ final readonly class MonitoringExecutionHandler
     ) {}
 
     /**
-     * Executes a monitoring provider with caching support if applicable.
+     * Executes a provider and returns the pure result only
      */
     public function executeProvider(MonitoringProvider $provider): Result
     {
-        if ($provider instanceof CacheableMonitoringProvider) {
-            return $this->executeWithCaching($provider);
-        }
-
-        return $provider->execute();
+        return $this->executeProviderWithMetadata($provider)->result;
     }
 
     /**
-     * Executes a cacheable provider with cache lookup and storage.
+     * Executes a provider and reports whether the result was served from cache.
      */
-    private function executeWithCaching(CacheableMonitoringProvider $provider): Result
+    public function executeProviderWithMetadata(MonitoringProvider $provider, bool $useCache = true): ProviderExecutionOutcome
     {
-        $cacheKey = $this->sanitizeCacheKey($provider->getCacheKey());
+        return $provider instanceof CacheableMonitoringProvider
+            ? $this->executeWithCaching($provider, $useCache)
+            : $this->executeWithoutCaching($provider);
+    }
 
-        $cachedResult = $this->cacheManager->getCachedResult($cacheKey);
+    private function executeWithoutCaching(MonitoringProvider $provider): ProviderExecutionOutcome
+    {
+        return new ProviderExecutionOutcome($provider->execute(), false);
+    }
 
-        if ($cachedResult !== null) {
-            return $cachedResult;
+    private function executeWithCaching(
+        CacheableMonitoringProvider $provider,
+        bool $useCache,
+    ): ProviderExecutionOutcome {
+        $cacheKey = $this->sanitizeIdentifier($provider->getCacheKey());
+
+        if ($useCache) {
+            $cachedResult = $this->cacheManager->getCachedResult($cacheKey);
+
+            if ($cachedResult !== null) {
+                return new ProviderExecutionOutcome($cachedResult, true);
+            }
         }
 
         $result = $provider->execute();
@@ -65,15 +76,15 @@ final readonly class MonitoringExecutionHandler
         $this->cacheManager->setCachedResult(
             $cacheKey,
             $result,
-            [str_replace('\\', '_', $provider::class)],
-            $provider->getCacheLifetime()
+            [$this->sanitizeIdentifier($provider::class)],
+            $provider->getCacheLifetime(),
         );
 
-        return $result;
+        return new ProviderExecutionOutcome($result, false);
     }
 
-    private function sanitizeCacheKey(string $string): string
+    private function sanitizeIdentifier(string $identifier): string
     {
-        return str_replace('\\', '_', $string);
+        return str_replace('\\', '_', $identifier);
     }
 }

--- a/Classes/Handler/ProviderExecutionOutcome.php
+++ b/Classes/Handler/ProviderExecutionOutcome.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Handler;
+
+use mteu\Monitoring\Result\Result;
+
+/**
+ * ProviderExecutionOutcome.
+ * Carries a provider's {@see Result} together with metadata about whether the outcome comes from cached analysis
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class ProviderExecutionOutcome
+{
+    public function __construct(
+        public Result $result,
+        public bool $fromCache,
+    ) {}
+}

--- a/Tests/Functional/Command/MonitoringCommandTest.php
+++ b/Tests/Functional/Command/MonitoringCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Functional\Command;
+
+use mteu\Monitoring\Cache\MonitoringCacheManager;
+use mteu\Monitoring\Command\MonitoringCommand;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Tests\Functional\Fixtures\CacheableProvider;
+use mteu\Monitoring\Tests\Functional\Fixtures\NonCacheableProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * MonitoringCommandTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(MonitoringCommand::class)]
+final class MonitoringCommandTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'monitoring',
+        'typed_extconf',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'caching' => [
+                'cacheConfigurations' => [
+                    'typo3_monitoring' => [
+                        'frontend' => 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend',
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                        'options' => [],
+                        'groups' => ['system'],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    private MonitoringExecutionHandler $executionHandler;
+    private MonitoringCacheManager $cacheManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executionHandler = $this->get(MonitoringExecutionHandler::class);
+        $this->cacheManager = $this->get(MonitoringCacheManager::class);
+        $this->cacheManager->flushAll();
+    }
+
+    #[Test]
+    public function reportsInvalidWhenNoActiveProvidersAreRegistered(): void
+    {
+        $tester = $this->createTester([]);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::INVALID, $exitCode);
+        self::assertStringContainsString('No active providers available', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function freshRunDoesNotLabelCacheableProvidersAsCached(): void
+    {
+        $provider = new CacheableProvider('fresh-provider');
+        $tester = $this->createTester([$provider]);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame(1, $provider->getExecutionCount());
+        self::assertStringNotContainsString('(cached)', $tester->getDisplay());
+        self::assertStringContainsString('fresh-provider', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function warmCacheCausesCacheableProvidersToBeLabelledAsCached(): void
+    {
+        $provider = new CacheableProvider('warm-provider');
+        $tester = $this->createTester([$provider]);
+
+        $tester->execute([]);
+        self::assertSame(1, $provider->getExecutionCount());
+
+        $tester->execute([]);
+
+        self::assertSame(1, $provider->getExecutionCount(), 'Warm cache must short-circuit execute()');
+        self::assertStringContainsString('(cached)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function noCacheOptionForcesFreshExecutionAndSuppressesCachedLabel(): void
+    {
+        $provider = new CacheableProvider('no-cache-provider');
+        $tester = $this->createTester([$provider]);
+
+        $tester->execute([]);
+        self::assertSame(1, $provider->getExecutionCount());
+
+        $tester->execute(['--no-cache' => true]);
+
+        self::assertSame(2, $provider->getExecutionCount(), '--no-cache must bypass the cache');
+        self::assertStringNotContainsString('(cached)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function nonCacheableProvidersAreNeverLabelledAsCached(): void
+    {
+        $provider = new NonCacheableProvider();
+        $tester = $this->createTester([$provider]);
+
+        $tester->execute([]);
+        $tester->execute([]);
+
+        self::assertSame(2, $provider->getExecutionCount());
+        self::assertStringNotContainsString('(cached)', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<int, MonitoringProvider> $providers
+     */
+    private function createTester(array $providers): CommandTester
+    {
+        $command = new MonitoringCommand($providers, $this->executionHandler);
+
+        return new CommandTester($command);
+    }
+}

--- a/Tests/Functional/Handler/MonitoringExecutionHandlerTest.php
+++ b/Tests/Functional/Handler/MonitoringExecutionHandlerTest.php
@@ -202,6 +202,45 @@ final class MonitoringExecutionHandlerTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function executeProviderWithMetadataReportsCacheMissOnFirstRun(): void
+    {
+        $outcome = $this->executionHandler->executeProviderWithMetadata($this->provider);
+
+        self::assertFalse($outcome->fromCache, 'First run must not be reported as a cache hit');
+        self::assertSame(1, $this->provider->getExecutionCount());
+    }
+
+    #[Test]
+    public function executeProviderWithMetadataReportsCacheHitOnSubsequentRun(): void
+    {
+        $this->executionHandler->executeProviderWithMetadata($this->provider);
+        $outcome = $this->executionHandler->executeProviderWithMetadata($this->provider);
+
+        self::assertTrue($outcome->fromCache, 'Warm cache must be reported as a cache hit');
+        self::assertSame(1, $this->provider->getExecutionCount(), 'Provider must not execute again');
+    }
+
+    #[Test]
+    public function executeProviderWithMetadataBypassesCacheWhenUseCacheIsFalse(): void
+    {
+        $this->executionHandler->executeProviderWithMetadata($this->provider);
+        $outcome = $this->executionHandler->executeProviderWithMetadata($this->provider, useCache: false);
+
+        self::assertFalse($outcome->fromCache, 'useCache=false must skip the cache lookup');
+        self::assertSame(2, $this->provider->getExecutionCount(), 'Provider must run again when cache is bypassed');
+    }
+
+    #[Test]
+    public function executeProviderWithMetadataReportsNonCacheableProvidersAsUncached(): void
+    {
+        $nonCacheableProvider = new NonCacheableProvider();
+
+        $outcome = $this->executionHandler->executeProviderWithMetadata($nonCacheableProvider);
+
+        self::assertFalse($outcome->fromCache);
+    }
+
+    #[Test]
     #[AllowMockObjectsWithoutExpectations]
     public function missingCacheBackendHandledGracefully(): void
     {

--- a/Tests/Unit/Command/MonitoringCommandTest.php
+++ b/Tests/Unit/Command/MonitoringCommandTest.php
@@ -17,14 +17,16 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Tests\Unit\Command;
 
+use mteu\Monitoring\Cache\MonitoringCacheManager;
 use mteu\Monitoring\Command\MonitoringCommand;
-use mteu\Monitoring\Provider\CacheableMonitoringProvider;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Provider\MonitoringProvider;
 use mteu\Monitoring\Result\MonitoringResult;
 use PHPUnit\Framework;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Cache\CacheManager;
 
 /**
  * MonitoringCommandTest.
@@ -40,7 +42,7 @@ final class MonitoringCommandTest extends Framework\TestCase
     {
         $inactiveProvider = $this->createProvider('Inactive', isActive: false, isHealthy: true);
 
-        $tester = new CommandTester(new MonitoringCommand([$inactiveProvider]));
+        $tester = new CommandTester(new MonitoringCommand([$inactiveProvider], $this->createExecutionHandler()));
         $exitCode = $tester->execute([]);
 
         self::assertSame(Command::INVALID, $exitCode);
@@ -52,7 +54,7 @@ final class MonitoringCommandTest extends Framework\TestCase
     {
         $healthy = $this->createProvider('HealthyProvider', isActive: true, isHealthy: true);
 
-        $tester = new CommandTester(new MonitoringCommand([$healthy]));
+        $tester = new CommandTester(new MonitoringCommand([$healthy], $this->createExecutionHandler()));
         $exitCode = $tester->execute([]);
 
         $display = $tester->getDisplay();
@@ -67,7 +69,7 @@ final class MonitoringCommandTest extends Framework\TestCase
     {
         $unhealthy = $this->createProvider('BrokenProvider', isActive: true, isHealthy: false);
 
-        $tester = new CommandTester(new MonitoringCommand([$unhealthy]));
+        $tester = new CommandTester(new MonitoringCommand([$unhealthy], $this->createExecutionHandler()));
         $exitCode = $tester->execute([]);
 
         $display = $tester->getDisplay();
@@ -82,49 +84,13 @@ final class MonitoringCommandTest extends Framework\TestCase
         $active = $this->createProvider('ActiveProvider', isActive: true, isHealthy: true);
         $inactive = $this->createProvider('InactiveProvider', isActive: false, isHealthy: true);
 
-        $tester = new CommandTester(new MonitoringCommand([$active, $inactive]));
+        $tester = new CommandTester(new MonitoringCommand([$active, $inactive], $this->createExecutionHandler()));
         $exitCode = $tester->execute([]);
 
         $display = $tester->getDisplay();
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertStringContainsString('ActiveProvider', $display);
         self::assertStringNotContainsString('InactiveProvider', $display);
-    }
-
-    #[Test]
-    public function marksCacheableProvidersAsCachedInOutput(): void
-    {
-        $cacheable = new class () implements CacheableMonitoringProvider {
-            public function getName(): string
-            {
-                return 'CacheableProvider';
-            }
-            public function getDescription(): string
-            {
-                return '';
-            }
-            public function isActive(): bool
-            {
-                return true;
-            }
-            public function execute(): MonitoringResult
-            {
-                return new MonitoringResult('CacheableProvider', true);
-            }
-            public function getCacheKey(): string
-            {
-                return 'cache-key';
-            }
-            public function getCacheLifetime(): int
-            {
-                return 60;
-            }
-        };
-
-        $tester = new CommandTester(new MonitoringCommand([$cacheable]));
-        $tester->execute([]);
-
-        self::assertStringContainsString('(cached)', $tester->getDisplay());
     }
 
     #[Test]
@@ -168,7 +134,7 @@ final class MonitoringCommandTest extends Framework\TestCase
             }
         };
 
-        $tester = new CommandTester(new MonitoringCommand([$healthy, $unhealthy]));
+        $tester = new CommandTester(new MonitoringCommand([$healthy, $unhealthy], $this->createExecutionHandler()));
         $exitCode = $tester->execute([]);
 
         $display = $tester->getDisplay();
@@ -183,7 +149,7 @@ final class MonitoringCommandTest extends Framework\TestCase
     {
         $plain = $this->createProvider('PlainProvider', isActive: true, isHealthy: true);
 
-        $tester = new CommandTester(new MonitoringCommand([$plain]));
+        $tester = new CommandTester(new MonitoringCommand([$plain], $this->createExecutionHandler()));
         $tester->execute([]);
 
         $display = $tester->getDisplay();
@@ -194,17 +160,26 @@ final class MonitoringCommandTest extends Framework\TestCase
     #[Test]
     public function commandIsRegisteredWithExpectedNameAndDescription(): void
     {
-        $command = new MonitoringCommand([]);
+        $command = new MonitoringCommand([], $this->createExecutionHandler());
 
         self::assertSame('monitoring:run', $command->getName());
         self::assertSame('This command runs monitoring.', $command->getDescription());
+    }
+
+    /**
+     * Builds a real execution handler whose cache backend is absent, so every
+     * provider runs fresh and is never reported from cache. Warm-cache and
+     * {@code --no-cache} behaviour is covered by the functional command test.
+     */
+    private function createExecutionHandler(): MonitoringExecutionHandler
+    {
+        return new MonitoringExecutionHandler(new MonitoringCacheManager(new CacheManager()));
     }
 
     private function createProvider(string $name, bool $isActive, bool $isHealthy): MonitoringProvider
     {
 
         return new readonly class ($name, $isActive, $isHealthy) implements MonitoringProvider {
-
             public function __construct(
                 private string $name,
                 private bool $active,


### PR DESCRIPTION
The command `monitoring:run` by-passed the cache and wrongfully mislabelled the output as "(cached)".