### PR TITLE
[TASK] Normalize monitoring endpoint

### DIFF
--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -24,7 +24,7 @@ use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
 /**
- * MonitoringConfiguration DTO.
+ * MonitoringConfiguration.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
@@ -32,13 +32,40 @@ use mteu\TypedExtConf\Attribute\ExtensionConfig;
 #[ExtensionConfig(extensionKey: 'monitoring')]
 final readonly class MonitoringConfiguration
 {
+    /**
+     * Normalized endpoint path: either an empty string (endpoint disabled) or
+     * a single leading slash with no trailing slash. Both consumers
+     * (MonitoringMiddleware::isValid(), MiddlewareStatusProvider::execute())
+     * assume this exact shape, so it is normalized here.
+     */
+    public string $endpoint;
+
     public function __construct(
         public TokenAuthorizerConfiguration $tokenAuthorizerConfiguration,
         public AdminUserAuthorizerConfiguration $adminUserAuthorizerConfiguration,
         public MiddlewareStatusProviderConfiguration $providerConfiguration,
         #[ExtConfProperty(path: 'api.endpoint')]
-        public string $endpoint = 'monitor/health',
+        string $endpoint = '/monitor/health',
         #[ExtConfProperty(path: 'api.enforceHttps')]
         public bool $enforceHttps = false,
-    ) {}
+    ) {
+        $this->endpoint = self::normalizeEndpoint($endpoint);
+    }
+
+    /**
+     * Forces a single leading slash and strips trailing slashes so the value
+     * always matches PSR-7's `UriInterface::getPath()` form. An empty (or
+     * whitespace-only) configured value disables the endpoint and is
+     * preserved as an empty string.
+     */
+    private static function normalizeEndpoint(string $endpoint): string
+    {
+        $trimmed = trim($endpoint);
+
+        if ($trimmed === '') {
+            return '';
+        }
+
+        return '/' . trim($trimmed, '/');
+    }
 }

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -549,6 +549,48 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
     }
 
     /**
+     * @return \Generator<string, array{string}>
+     */
+    public static function endpointInputFormProvider(): \Generator
+    {
+        yield 'canonical leading slash' => ['/monitor/health'];
+        yield 'missing leading slash (DTO default regression)' => ['monitor/health'];
+        yield 'trailing slash' => ['/monitor/health/'];
+        yield 'redundant slashes' => ['//monitor/health//'];
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    #[DataProvider('endpointInputFormProvider')]
+    public function endpointMatchesRegardlessOfConfiguredSlashForm(string $configuredEndpoint): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => $configuredEndpoint],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $middleware = new MonitoringMiddleware(
+            [$this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler(),
+        );
+
+        // The request path always has a single leading slash (PSR-7). The
+        // health endpoint must match no matter which slash form the operator
+        // configured, otherwise the middleware silently passes everything
+        // through and the endpoint effectively does not exist.
+        $response = $middleware->process(
+            new ServerRequest(new Uri('https://example.com/monitor/health'), 'GET'),
+            $this->handler,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
      * @param mixed[] $configurationData
      */
     private function createConfigurationFromData(array $configurationData): MonitoringConfiguration


### PR DESCRIPTION
The `MonitoringConfiguration` was wrong in providing the `#[ExtConfProperty(path: 'api.endpoint')]` fallback without a leading slash.

It now forces a single leading slash and strips trailing slashes so the value always matches PSR-7's `UriInterface::getPath()` form. Since an empty (or whitespace-only) configured value disables the endpoint it is preserved as an empty string.