### PR TITLE
[BUGFIX] Only execute active providers in BE module

### DIFF
--- a/Classes/Backend/Controller/MonitoringController.php
+++ b/Classes/Backend/Controller/MonitoringController.php
@@ -141,7 +141,7 @@ final readonly class MonitoringController
      *     name: string,
      *     isCached: bool,
      *     isActive: bool,
-     *     isHealthy: bool,
+     *     isHealthy?: bool,
      *     description: string,
      *     cacheLifetime?: int,
      *     subResults?: array<\mteu\Monitoring\Result\Result>,
@@ -161,15 +161,23 @@ final readonly class MonitoringController
                 continue;
             }
 
-            $result = $this->executionHandler->executeProvider($monitoringProvider);
+            $isActive = $monitoringProvider->isActive();
 
             $providerTemplateVariables[$monitoringProvider::class] = [
                 'name' => $monitoringProvider->getName(),
                 'isCached' => $monitoringProvider instanceof CacheableMonitoringProvider,
-                'isActive' => $monitoringProvider->isActive(),
-                'isHealthy' => $result->isHealthy(),
+                'isActive' => $isActive,
                 'description' => $monitoringProvider->getDescription(),
             ];
+
+            if ($isActive) {
+                $result = $this->executionHandler->executeProvider($monitoringProvider);
+                $providerTemplateVariables[$monitoringProvider::class]['isHealthy'] = $result->isHealthy();
+
+                if ($result->hasSubResults()) {
+                    $providerTemplateVariables[$monitoringProvider::class]['subResults'] = $result->getSubResults();
+                }
+            }
 
             if ($monitoringProvider instanceof CacheableMonitoringProvider) {
                 $providerTemplateVariables[$monitoringProvider::class]['cacheLifetime'] = $monitoringProvider->getCacheLifetime();
@@ -178,10 +186,6 @@ final readonly class MonitoringController
                     FlushProviderCacheController::CSRF_TOKEN_ACTION,
                     $monitoringProvider::class,
                 );
-            }
-
-            if ($result->hasSubResults()) {
-                $providerTemplateVariables[$monitoringProvider::class]['subResults'] = $result->getSubResults();
             }
 
             // Check for cache expiration time

--- a/Tests/Unit/Backend/Controller/MonitoringControllerTest.php
+++ b/Tests/Unit/Backend/Controller/MonitoringControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Backend\Controller;
+
+use mteu\Monitoring\Backend\Controller\MonitoringController;
+use mteu\Monitoring\Cache\MonitoringCacheManager;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Result\MonitoringResult;
+use PHPUnit\Framework;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\FormProtection\AbstractFormProtection;
+use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
+
+/**
+ * MonitoringControllerTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(MonitoringController::class)]
+final class MonitoringControllerTest extends Framework\TestCase
+{
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function inactiveProviderIsNeitherExecutedNorAssignedAHealthValue(): void
+    {
+        $inactiveProvider = $this->createMock(MonitoringProvider::class);
+        $inactiveProvider->method('getName')->willReturn('Inactive');
+        $inactiveProvider->method('getDescription')->willReturn('disabled provider');
+        $inactiveProvider->method('isActive')->willReturn(false);
+
+        $inactiveProvider->expects(self::never())->method('execute');
+
+        $variables = $this->buildProviderTemplateVariables([$inactiveProvider]);
+
+        self::assertArrayHasKey($inactiveProvider::class, $variables);
+        $entry = $variables[$inactiveProvider::class];
+
+        self::assertFalse($entry['isActive']);
+
+        // "Not checked" must not masquerade as a health verdict.
+        self::assertArrayNotHasKey('isHealthy', $entry);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function activeProviderIsExecutedOnceAndReportsItsHealth(): void
+    {
+        $activeProvider = $this->createMock(MonitoringProvider::class);
+        $activeProvider->method('getName')->willReturn('Active');
+        $activeProvider->method('getDescription')->willReturn('enabled provider');
+        $activeProvider->method('isActive')->willReturn(true);
+        $activeProvider
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn(new MonitoringResult('Active', true));
+
+        $variables = $this->buildProviderTemplateVariables([$activeProvider]);
+
+        $entry = $variables[$activeProvider::class];
+
+        self::assertTrue($entry['isActive']);
+        self::assertArrayHasKey('isHealthy', $entry);
+        self::assertTrue($entry['isHealthy']);
+    }
+
+    /**
+     * Invokes the private buildProviderTemplateVariables() on a controller
+     * created without its constructor, injecting only the four properties the
+     * method actually reads.
+     *
+     * @param list<MonitoringProvider> $providers
+     * @return array<class-string<MonitoringProvider>, array<string, mixed>>
+     */
+    private function buildProviderTemplateVariables(array $providers): array
+    {
+        $executionHandler = new MonitoringExecutionHandler(
+            new MonitoringCacheManager($this->createMock(CacheManager::class)),
+        );
+
+        $formProtectionFactory = $this->createMock(FormProtectionFactory::class);
+        $formProtectionFactory
+            ->method('createFromRequest')
+            ->willReturn($this->createMock(AbstractFormProtection::class));
+
+        $reflection = new \ReflectionClass(MonitoringController::class);
+        $controller = $reflection->newInstanceWithoutConstructor();
+
+        foreach ([
+            'monitoringProviders' => $providers,
+            'executionHandler' => $executionHandler,
+            'cacheManager' => new MonitoringCacheManager($this->createMock(CacheManager::class)),
+            'formProtectionFactory' => $formProtectionFactory,
+        ] as $property => $value) {
+            $reflection->getProperty($property)->setValue($controller, $value);
+        }
+
+        $method = $reflection->getMethod('buildProviderTemplateVariables');
+
+        $result = $method->invoke($controller, $this->createMock(ServerRequestInterface::class));
+        self::assertIsArray($result);
+
+        /** @var array<class-string<MonitoringProvider>, array<string, mixed>> $result */
+        return $result;
+    }
+}

--- a/Tests/Unit/Configuration/MonitoringConfigurationTest.php
+++ b/Tests/Unit/Configuration/MonitoringConfigurationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Configuration;
+
+use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Provider\MiddlewareStatusProviderConfiguration;
+use PHPUnit\Framework;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * MonitoringConfigurationTest.
+ *
+ * Pins the endpoint-normalization contract. Both consumers
+ * (MonitoringMiddleware::isValid(), MiddlewareStatusProvider::execute())
+ * assume `endpoint` is either '' (disabled) or a single leading slash with
+ * no trailing slash. A regression here silently disables the health endpoint
+ * or produces a malformed self-request URL.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(MonitoringConfiguration::class)]
+final class MonitoringConfigurationTest extends Framework\TestCase
+{
+    #[Test]
+    public function defaultEndpointIsTheCanonicalLeadingSlashForm(): void
+    {
+        self::assertSame('/monitor/health', $this->createConfiguration()->endpoint);
+    }
+
+    #[Test]
+    #[DataProvider('endpointNormalizationProvider')]
+    public function endpointIsNormalizedToASingleLeadingSlashWithoutTrailingSlash(
+        string $configured,
+        string $expected,
+    ): void {
+        self::assertSame($expected, $this->createConfigurationWithEndpoint($configured)->endpoint);
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function endpointNormalizationProvider(): \Generator
+    {
+        yield 'canonical leading slash' => ['/monitor/health', '/monitor/health'];
+        yield 'missing leading slash' => ['monitor/health', '/monitor/health'];
+        yield 'trailing slash' => ['/monitor/health/', '/monitor/health'];
+        yield 'redundant slashes' => ['//monitor/health//', '/monitor/health'];
+        yield 'surrounding whitespace' => ['  /monitor/health  ', '/monitor/health'];
+        yield 'custom path no slash' => ['health', '/health'];
+        yield 'empty string stays empty' => ['', ''];
+        yield 'whitespace-only disables' => ['   ', ''];
+    }
+
+    private function createConfiguration(): MonitoringConfiguration
+    {
+        return new MonitoringConfiguration(
+            new TokenAuthorizerConfiguration(),
+            new AdminUserAuthorizerConfiguration(),
+            new MiddlewareStatusProviderConfiguration(),
+        );
+    }
+
+    private function createConfigurationWithEndpoint(string $endpoint): MonitoringConfiguration
+    {
+        return new MonitoringConfiguration(
+            new TokenAuthorizerConfiguration(),
+            new AdminUserAuthorizerConfiguration(),
+            new MiddlewareStatusProviderConfiguration(),
+            $endpoint,
+        );
+    }
+}


### PR DESCRIPTION
`MonitoringController::buildProviderTemplateVariables()` called `executeProvider()` for every registered provider regardless of `isActive()`, while the middleware (`getHealthStatus()`) and CLI (`MonitoringCommand`) both respected the state.