### PR TITLE
[TASK] Replace magic getter with fluid-friendly accessor

### DIFF
--- a/Classes/Result/MonitoringResult.php
+++ b/Classes/Result/MonitoringResult.php
@@ -57,6 +57,14 @@ final class MonitoringResult implements Result
         return true;
     }
 
+    /**
+     * Fluid-friendly accessor for {@see isHealthy()}.
+     */
+    public function getIsHealthy(): bool
+    {
+        return $this->isHealthy();
+    }
+
     public function setHealthy(bool $isHealthy): Result
     {
         $this->isHealthy = $isHealthy;
@@ -94,22 +102,6 @@ final class MonitoringResult implements Result
         $this->subResults[] = $result;
 
         return $result;
-    }
-
-    /**
-     * Magic getter for Fluid templates to access private properties as way dirty workaround to Fluid's inability to
-     * invoke the `isHealthy()` method instead of directly accessing the property with the exact same name.
-     */
-    public function __get(string $property): mixed
-    {
-        return match ($property) {
-            'name' => $this->name,
-            'isHealthy' => $this->isHealthy,
-            'description' => $this->reason,
-            default => throw new \InvalidArgumentException(
-                sprintf('Property "%s" does not exist on %s', $property, self::class)
-            ),
-        };
     }
 
     /**

--- a/Tests/Unit/MonitoringTestCase.php
+++ b/Tests/Unit/MonitoringTestCase.php
@@ -148,16 +148,4 @@ abstract class MonitoringTestCase extends TestCase
         yield 'unhealthy parent, unhealthy subs' => [false, [false, false], false];
     }
 
-    /**
-     * Creates common property test scenarios for magic getter testing.
-     *
-     * @return \Generator<string, array{0: string, 1: bool, 2: string|null, 3: string, 4: mixed}>
-     */
-    final public static function propertyAccessScenarios(): \Generator
-    {
-        yield 'name property access' => ['test-service', true, 'All good', 'name', 'test-service'];
-        yield 'isHealthy property access' => ['test-service', false, 'Error occurred', 'isHealthy', false];
-        yield 'description property with value' => ['test-service', true, 'Service operational', 'description', 'Service operational'];
-        yield 'description property when null' => ['test-service', true, null, 'description', null];
-    }
 }

--- a/Tests/Unit/Result/MonitoringResultTest.php
+++ b/Tests/Unit/Result/MonitoringResultTest.php
@@ -128,29 +128,20 @@ final class MonitoringResultTest extends MonitoringTestCase
         self::assertSame($allExpected, $result->getSubResults(), 'Order should be maintained');
     }
 
+    /**
+     * @param list<bool> $subHealthStatuses
+     */
     #[Test]
-    #[DataProvider('propertyAccessScenarios')]
-    public function magicGetterReturnsExpectedPropertyValues(
-        string $name,
-        bool $isHealthy,
-        ?string $reason,
-        string $property,
-        mixed $expectedValue
+    #[DataProvider('healthCalculationScenarios')]
+    public function getIsHealthyMatchesIsHealthyIncludingSubResultFolding(
+        bool $initialHealth,
+        array $subHealthStatuses,
+        bool $expectedHealth
     ): void {
-        $result = new MonitoringResult($name, $isHealthy, $reason);
+        $result = $this->createResultWithSubResults($subHealthStatuses, 'test', $initialHealth);
 
-        self::assertSame($expectedValue, $result->__get($property));
-    }
-
-    #[Test]
-    public function magicGetterThrowsForInvalidProperty(): void
-    {
-        $result = new MonitoringResult('test', true);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Property "invalid" does not exist');
-
-        $result->__get('invalid');
+        self::assertSame($expectedHealth, $result->getIsHealthy());
+        self::assertSame($result->isHealthy(), $result->getIsHealthy());
     }
 
     /**


### PR DESCRIPTION
Fluid's property accessor prefers `get<Property>()` over magic `__get()`, so `{result.isHealthy}` will use this getter.