### PR TITLE
[FEATURE] Make cacheLifetime configurable

### DIFF
--- a/Classes/Cache/MonitoringCacheManager.php
+++ b/Classes/Cache/MonitoringCacheManager.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Cache;
 
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
 use mteu\Monitoring\Result\CachedMonitoringResult;
 use mteu\Monitoring\Result\Result;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -36,9 +37,11 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 final readonly class MonitoringCacheManager
 {
     private const string CACHE_IDENTIFIER = 'typo3_monitoring';
+    private const int FALLBACK_LIFETIME = 60 * 15;
 
     public function __construct(
         private CacheManager $cacheManager,
+        private ?MonitoringConfiguration $configuration = null,
     ) {}
 
     /**
@@ -138,11 +141,16 @@ final readonly class MonitoringCacheManager
     /**
      * Gets the default cache lifetime in seconds.
      *
-     * @return int Default cache lifetime (15 minutes)
+     * Reads `cache.defaultLifetime` from the extension configuration when
+     * available, falling back to 15 minutes when no configuration is wired.
      */
     public function getCacheLifetime(): int
     {
-        return 60 * 15;
+        if ($this->configuration === null) {
+            return self::FALLBACK_LIFETIME;
+        }
+
+        return $this->configuration->cacheDefaultLifetime;
     }
 
     /**

--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -48,6 +48,8 @@ final readonly class MonitoringConfiguration
         string $endpoint = '/monitor/health',
         #[ExtConfProperty(path: 'api.enforceHttps')]
         public bool $enforceHttps = false,
+        #[ExtConfProperty(path: 'cache.defaultLifetime')]
+        public int $cacheDefaultLifetime = 900,
     ) {
         $this->endpoint = self::normalizeEndpoint($endpoint);
     }

--- a/Tests/Unit/Cache/MonitoringCacheManagerTest.php
+++ b/Tests/Unit/Cache/MonitoringCacheManagerTest.php
@@ -18,6 +18,10 @@ declare(strict_types=1);
 namespace mteu\Monitoring\Tests\Unit\Cache;
 
 use mteu\Monitoring\Cache\MonitoringCacheManager;
+use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Provider\MiddlewareStatusProviderConfiguration;
 use mteu\Monitoring\Result\CachedMonitoringResult;
 use mteu\Monitoring\Result\MonitoringResult;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -121,6 +125,37 @@ final class MonitoringCacheManagerTest extends TestCase
         $result = $this->monitoringCacheManager->getCacheLifetime();
 
         self::assertSame(900, $result, 'Should return 15 minutes (900 seconds) as default');
+    }
+
+    #[Test]
+    public function getCacheLifetimeHonorsConfiguredDefault(): void
+    {
+        $cacheManager = $this->createMock(CacheManager::class);
+        $monitoringCacheManager = new MonitoringCacheManager(
+            $cacheManager,
+            $this->createConfiguration(cacheDefaultLifetime: 60),
+        );
+
+        self::assertSame(60, $monitoringCacheManager->getCacheLifetime());
+    }
+
+    #[Test]
+    public function getCacheLifetimeFallsBackToBuiltInDefaultWhenConfigurationOmitted(): void
+    {
+        $cacheManager = $this->createMock(CacheManager::class);
+        $monitoringCacheManager = new MonitoringCacheManager($cacheManager);
+
+        self::assertSame(900, $monitoringCacheManager->getCacheLifetime());
+    }
+
+    private function createConfiguration(int $cacheDefaultLifetime): MonitoringConfiguration
+    {
+        return new MonitoringConfiguration(
+            new TokenAuthorizerConfiguration(true, 10, 'secret', 'X-TYPO3-MONITORING-AUTH'),
+            new AdminUserAuthorizerConfiguration(),
+            new MiddlewareStatusProviderConfiguration(),
+            cacheDefaultLifetime: $cacheDefaultLifetime,
+        );
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -5,6 +5,11 @@ api {
     enforceHttps=0
 }
 
+cache {
+    # cat=cache/defaultLifetime; type=int+; label=Default cache lifetime (seconds):Fleet-wide default lifetime for monitoring results in seconds. Individual CacheableMonitoringProvider implementations may override this via getCacheLifetime(). Defaults to 900 (15 minutes).
+    defaultLifetime=900
+}
+
 authorizer {
     mteu\Monitoring\Authorization\TokenAuthorizer {
         # cat=TokenAuthorizer/Enabled//10; type=boolean; label=Enable TokenAuthorizer: Enables the access to health status via Token in the Request Header


### PR DESCRIPTION
`MonitoringCacheManager::getCacheLifetime()` previously returned a hard-coded 15 minutes with no global override. Operators monitoring fast-changing services had to subclass the manager to shorten the default; operators with expensive checks couldn't lengthen it.
