### PR TITLE
[FEATURE] Add `EmailReporter`

### DIFF
--- a/Classes/Cache/NotificationStateCacheManager.php
+++ b/Classes/Cache/NotificationStateCacheManager.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Cache;
+
+use mteu\Monitoring\Reporter\NotificationState;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+
+/**
+ * NotificationStateStore.
+ *
+ * Persists the dedup state in a dedicated cache (`typo3_monitoring_notification`)
+ * which is intentionally NOT in the "system" cache group, so routine
+ * "flush system caches" / provider-cache-flush actions cannot make the
+ * notifier forget that it already alerted.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class NotificationStateCacheManager
+{
+    private const string CACHE_IDENTIFIER = 'typo3_monitoring_notification';
+    private const string STATE_KEY = 'notification_state';
+
+    public function __construct(
+        private CacheManager $cacheManager,
+    ) {}
+
+    public function load(): ?NotificationState
+    {
+        try {
+            $cache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
+
+            if (!$cache->has(self::STATE_KEY)) {
+                return null;
+            }
+
+            $state = $cache->get(self::STATE_KEY);
+
+            return $state instanceof NotificationState ? $state : null;
+        } catch (NoSuchCacheException) {
+            return null;
+        }
+    }
+
+    public function save(NotificationState $state): bool
+    {
+        try {
+            $this->cacheManager
+                ->getCache(self::CACHE_IDENTIFIER)
+                ->set(self::STATE_KEY, $state);
+
+            return true;
+        } catch (NoSuchCacheException) {
+            return false;
+        }
+    }
+}

--- a/Classes/Command/ReportCommand.php
+++ b/Classes/Command/ReportCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Command;
+
+use mteu\Monitoring\Reporter\NotificationDecision;
+use mteu\Monitoring\Reporter\ReportDispatcher;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ReportCommand.
+ *
+ * Cron-friendly trigger for the push reporters. Thin wrapper around
+ * {@see ReportDispatcher} so it stays identical to the (optional)
+ * scheduler task.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[AsCommand(name: 'monitoring:report')]
+final class ReportCommand extends Command
+{
+    public function __construct(
+        private readonly ReportDispatcher $dispatcher,
+    ) {
+        parent::__construct(name: 'monitoring:report');
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->setDescription('Evaluates monitoring status and dispatches push notifications to active reporters.');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $decision = $this->dispatcher->dispatch();
+
+        $output->writeln(match ($decision) {
+            NotificationDecision::None => 'No notification dispatched.',
+            NotificationDecision::Unhealthy => 'Dispatched: unhealthy status.',
+            NotificationDecision::Reminder => 'Dispatched: reminder for ongoing unhealthy status.',
+            NotificationDecision::Recovered => 'Dispatched: recovery notice.',
+        });
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -19,6 +19,8 @@ namespace mteu\Monitoring\Configuration;
 
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
@@ -42,6 +44,8 @@ final readonly class MonitoringConfiguration
     public function __construct(
         public TokenAuthorizerConfiguration $tokenAuthorizerConfiguration,
         public AdminUserAuthorizerConfiguration $adminUserAuthorizerConfiguration,
+        public EmailReporterConfiguration $emailReporterConfiguration,
+        public ReportDispatcherConfiguration $reporterDispatcherConfiguration,
         #[ExtConfProperty(path: 'api.endpoint')]
         string $endpoint = '/monitor/health',
         #[ExtConfProperty(path: 'api.enforceHttps')]

--- a/Classes/Configuration/Reporter/EmailReporterConfiguration.php
+++ b/Classes/Configuration/Reporter/EmailReporterConfiguration.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Configuration\Reporter;
+
+use mteu\Monitoring\Reporter\ReportThreshold;
+use mteu\TypedExtConf\Attribute\ExtConfProperty;
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
+
+/**
+ * EmailReporterConfiguration.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[ExtensionConfig(extensionKey: 'monitoring')]
+final readonly class EmailReporterConfiguration implements ReporterConfiguration
+{
+    public function __construct(
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.enabled')]
+        public bool $enabled = false,
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.priority')]
+        public int $priority = 10,
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.threshold')]
+        public string $threshold = 'unhealthy',
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.recipients')]
+        public string $recipients = '',
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.senderAddress')]
+        public string $senderAddress = '',
+        #[ExtConfProperty(path: 'reporter.mteu\\Monitoring\\Reporter\\EmailReporter.subjectPrefix')]
+        public string $subjectPrefix = '[Monitoring]',
+    ) {}
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function getThreshold(): ReportThreshold
+    {
+        return ReportThreshold::fromConfigValue($this->threshold);
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public function getRecipients(): array
+    {
+        $recipients = [];
+
+        foreach (explode(',', $this->recipients) as $recipient) {
+            $recipient = trim($recipient);
+
+            if ($recipient !== '') {
+                $recipients[] = $recipient;
+            }
+        }
+
+        return $recipients;
+    }
+}

--- a/Classes/Configuration/Reporter/ReportDispatcherConfiguration.php
+++ b/Classes/Configuration/Reporter/ReportDispatcherConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Configuration\Reporter;
+
+use mteu\TypedExtConf\Attribute\ExtConfProperty;
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
+
+/**
+ * ReportDispatcherConfiguration.
+ *
+ * Global behaviour of the dedup state machine shared by all reporters.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[ExtensionConfig(extensionKey: 'monitoring')]
+final readonly class ReportDispatcherConfiguration
+{
+    public function __construct(
+        #[ExtConfProperty(path: 'reportDispatcher.reminderInterval')]
+        public int $reminderInterval = 86400,
+        #[ExtConfProperty(path: 'reportDispatcher.notifyOnRecovery')]
+        public bool $notifyOnRecovery = true,
+        #[ExtConfProperty(path: 'reportDispatcher.failOpenOnMissingState')]
+        public bool $failOpenOnMissingState = true,
+    ) {}
+}

--- a/Classes/Configuration/Reporter/ReporterConfiguration.php
+++ b/Classes/Configuration/Reporter/ReporterConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Configuration\Reporter;
+
+use mteu\Monitoring\Reporter\ReportThreshold;
+
+/**
+ * ReporterConfiguration.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+interface ReporterConfiguration
+{
+    public function isEnabled(): bool;
+    public function getPriority(): int;
+    public function getThreshold(): ReportThreshold;
+}

--- a/Classes/Reporter/EmailReporter.php
+++ b/Classes/Reporter/EmailReporter.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mime\Address;
+use TYPO3\CMS\Core\Mail\MailerInterface;
+use TYPO3\CMS\Core\Mail\MailMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * EmailReporter.
+ *
+ * Sends the monitoring status via TYPO3's core mailer. SMTP/transport
+ * credentials come from `$GLOBALS['TYPO3_CONF_VARS']['MAIL']` and are never
+ * stored in extension configuration.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class EmailReporter implements Reporter
+{
+    public function __construct(
+        private EmailReporterConfiguration $configuration,
+        private MailerInterface $mailer,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function isActive(): bool
+    {
+        return $this->configuration->isEnabled() && $this->configuration->getRecipients() !== [];
+    }
+
+    public function getThreshold(): ReportThreshold
+    {
+        return $this->configuration->getThreshold();
+    }
+
+    public function report(ReportContext $context): bool
+    {
+        $recipients = $this->configuration->getRecipients();
+
+        if ($recipients === []) {
+            return false;
+        }
+
+        try {
+            $message = new MailMessage();
+            $message
+                ->to(...$recipients)
+                ->subject($this->buildSubject($context))
+                ->text($this->buildBody($context));
+
+            if ($this->configuration->senderAddress !== '') {
+                $message->from(new Address($this->configuration->senderAddress));
+            }
+
+            $this->mailer->send($message);
+
+            return true;
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->error('EmailReporter failed to send monitoring report', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'EmailReporter';
+    }
+
+    public static function getPriority(): int
+    {
+        // MakeInstance is unavoidable inside this static method
+        $config = GeneralUtility::makeInstance(EmailReporterConfiguration::class);
+
+        return $config->getPriority();
+    }
+
+    private function buildSubject(ReportContext $context): string
+    {
+        $prefix = $this->configuration->subjectPrefix;
+        $prefix = $prefix === '' ? '' : $prefix . ' ';
+
+        $summary = match ($context->decision) {
+            NotificationDecision::Recovered => 'All monitored services recovered',
+            NotificationDecision::Reminder => sprintf(
+                'Still unhealthy: %s',
+                implode(', ', $context->unhealthyProviderNames),
+            ),
+            NotificationDecision::Unhealthy, NotificationDecision::None => sprintf(
+                'Unhealthy: %s',
+                implode(', ', $context->unhealthyProviderNames),
+            ),
+        };
+
+        return $prefix . $summary;
+    }
+
+    private function buildBody(ReportContext $context): string
+    {
+        $lines = [];
+
+        $lines[] = match ($context->decision) {
+            NotificationDecision::Recovered => 'All monitored services are healthy again.',
+            NotificationDecision::Reminder => 'The following services are still reporting an unhealthy state:',
+            NotificationDecision::Unhealthy, NotificationDecision::None => 'The following services are reporting an unhealthy state:',
+        };
+        $lines[] = '';
+
+        foreach ($context->results as $result) {
+            $status = $result->isHealthy() ? 'OK' : 'FAILED';
+            $reason = $result->getReason();
+            $lines[] = sprintf(
+                '[%s] %s%s',
+                $status,
+                $result->getName(),
+                $reason !== null && $reason !== '' ? ' — ' . $reason : '',
+            );
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+}

--- a/Classes/Reporter/NotificationDecision.php
+++ b/Classes/Reporter/NotificationDecision.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+/**
+ * NotificationDecision.
+ *
+ * Outcome of the dispatcher's dedup state machine for a single run.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+enum NotificationDecision
+{
+    /** Nothing to send (healthy with no prior outage, or throttled within the reminder interval). */
+    case None;
+
+    /** Unhealthy and either a new outage or a changed failure set: notify now. */
+    case Unhealthy;
+
+    /** Same failure set, reminder interval elapsed: send a reminder. */
+    case Reminder;
+
+    /** Status returned to healthy after an outage: send a one-off recovery notice. */
+    case Recovered;
+
+    public function shouldDispatch(): bool
+    {
+        return $this !== self::None;
+    }
+}

--- a/Classes/Reporter/NotificationState.php
+++ b/Classes/Reporter/NotificationState.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+/**
+ * NotificationState.
+ *
+ * Persisted between dispatcher runs so the dedup state machine can decide
+ * whether the current status warrants a (renewed) notification.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class NotificationState
+{
+    public function __construct(
+        public ?string $fingerprint,
+        public int $lastNotifiedAt,
+        public bool $wasHealthy,
+    ) {}
+}

--- a/Classes/Reporter/ReportContext.php
+++ b/Classes/Reporter/ReportContext.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+use mteu\Monitoring\Result\Result;
+
+/**
+ * ReportContext.
+ *
+ * Immutable payload handed to every {@see Reporter} so it can render an
+ * accurate message ("new failure" / "still failing" / "recovered") without
+ * re-deriving dispatcher state.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class ReportContext
+{
+    /**
+     * @param array<non-empty-string, Result> $results full active-provider result set, keyed by provider name
+     * @param list<string> $unhealthyProviderNames human-readable names of failing providers (sorted)
+     */
+    public function __construct(
+        public NotificationDecision $decision,
+        public array $results,
+        public array $unhealthyProviderNames,
+        public ?string $fingerprint,
+    ) {}
+
+    public function isHealthy(): bool
+    {
+        return $this->unhealthyProviderNames === [];
+    }
+}

--- a/Classes/Reporter/ReportDispatcher.php
+++ b/Classes/Reporter/ReportDispatcher.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+use mteu\Monitoring\Cache\NotificationStateCacheManager;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Result\Result;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * ReportDispatcher.
+ *
+ * Shared "brain" used by both the CLI command and the (optional) scheduler
+ * task: evaluates active providers, runs the dedup state machine, and fans
+ * out to active reporters according to each reporter's threshold.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class ReportDispatcher
+{
+    public function __construct(
+        /** @var iterable<MonitoringProvider> $monitoringProviders */
+        #[AutowireIterator(tag: 'monitoring.provider')]
+        private iterable $monitoringProviders,
+
+        /** @var iterable<Reporter> $reporters */
+        #[AutowireIterator(tag: 'monitoring.reporter', defaultPriorityMethod: 'getPriority')]
+        private iterable $reporters,
+        private MonitoringExecutionHandler $executionHandler,
+        private NotificationStateCacheManager $stateCacheManager,
+        private MonitoringConfiguration $configuration,
+        private Context $context,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function dispatch(): NotificationDecision
+    {
+        $results = $this->collectResults();
+
+        $unhealthyNames = [];
+        foreach ($results as $name => $result) {
+            if (!$result->isHealthy()) {
+                $unhealthyNames[] = $name;
+            }
+        }
+        sort($unhealthyNames);
+
+        $healthyNow = $unhealthyNames === [];
+        $fingerprint = $healthyNow ? null : sha1(implode("\n", $unhealthyNames));
+
+        $now = $this->now();
+
+        $state = $this->stateCacheManager->load();
+
+        $dispatcherConfiguration = $this->configuration->reporterDispatcherConfiguration;
+
+        $decision = $this->decide(
+            $healthyNow,
+            $fingerprint,
+            $state,
+            $now,
+            $dispatcherConfiguration->reminderInterval,
+            $dispatcherConfiguration->notifyOnRecovery,
+            $dispatcherConfiguration->failOpenOnMissingState,
+        );
+
+        $reportContext = new ReportContext($decision, $results, $unhealthyNames, $fingerprint);
+
+        $anySent = $decision->shouldDispatch() && $this->fanOut($reportContext);
+
+        $this->persist($healthyNow, $fingerprint, $decision, $anySent, $state, $now);
+
+        return $decision;
+    }
+
+    private function decide(
+        bool $healthyNow,
+        ?string $fingerprint,
+        ?NotificationState $state,
+        int $now,
+        int $reminderInterval,
+        bool $notifyOnRecovery,
+        bool $failOpenOnMissingState,
+    ): NotificationDecision {
+        if ($healthyNow) {
+            if ($state !== null && !$state->wasHealthy && $notifyOnRecovery) {
+                return NotificationDecision::Recovered;
+            }
+
+            return NotificationDecision::None;
+        }
+
+        if ($state === null) {
+            return $failOpenOnMissingState ? NotificationDecision::Unhealthy : NotificationDecision::None;
+        }
+
+        if ($state->fingerprint !== $fingerprint) {
+            return NotificationDecision::Unhealthy;
+        }
+
+        if ($now - $state->lastNotifiedAt >= $reminderInterval) {
+            return NotificationDecision::Reminder;
+        }
+
+        return NotificationDecision::None;
+    }
+
+    private function persist(
+        bool $healthyNow,
+        ?string $fingerprint,
+        NotificationDecision $decision,
+        bool $anySent,
+        ?NotificationState $state,
+        int $now,
+    ): void {
+        $previousLastNotified = $state !== null ? $state->lastNotifiedAt : 0;
+
+        if ($healthyNow) {
+            $lastNotifiedAt = $decision === NotificationDecision::Recovered ? $now : $previousLastNotified;
+            $this->stateCacheManager->save(new NotificationState(null, $lastNotifiedAt, true));
+
+            return;
+        }
+
+        // Only advance the reminder clock when a notification was actually
+        // delivered, so a failed send is retried on the next run.
+        $lastNotifiedAt = $anySent ? $now : $previousLastNotified;
+        $this->stateCacheManager->save(new NotificationState($fingerprint, $lastNotifiedAt, false));
+    }
+
+    private function fanOut(ReportContext $context): bool
+    {
+        $anySent = false;
+
+        foreach ($this->reporters as $reporter) {
+            if (!$reporter->isActive()) {
+                continue;
+            }
+
+            if (!$this->reporterAccepts($reporter, $context->decision)) {
+                continue;
+            }
+
+            try {
+                if ($reporter->report($context)) {
+                    $anySent = true;
+                } else {
+                    $this->logger->warning('Reporter did not deliver the monitoring report', [
+                        'reporter' => $reporter->getName(),
+                        'decision' => $context->decision->name,
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error('Reporter threw while delivering the monitoring report', [
+                    'reporter' => $reporter->getName(),
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $anySent;
+    }
+
+    private function reporterAccepts(Reporter $reporter, NotificationDecision $decision): bool
+    {
+        return match ($reporter->getThreshold()) {
+            ReportThreshold::Always => true,
+            ReportThreshold::Unhealthy => $decision === NotificationDecision::Unhealthy
+                || $decision === NotificationDecision::Reminder,
+            ReportThreshold::StateChange => $decision === NotificationDecision::Unhealthy
+                || $decision === NotificationDecision::Recovered,
+        };
+    }
+
+    /**
+     * Keyed by the provider's name (matching the middleware's status map) so
+     * two instances of the same provider class do not collide.
+     *
+     * @return array<non-empty-string, Result>
+     */
+    private function collectResults(): array
+    {
+        $results = [];
+
+        foreach ($this->monitoringProviders as $provider) {
+            if ($provider->isActive()) {
+                $results[$provider->getName()] = $this->executionHandler->executeProvider($provider);
+            }
+        }
+
+        return $results;
+    }
+
+    private function now(): int
+    {
+        $timestamp = $this->context->getPropertyFromAspect('date', 'timestamp');
+
+        return is_int($timestamp) ? $timestamp : time();
+    }
+}

--- a/Classes/Reporter/ReportThreshold.php
+++ b/Classes/Reporter/ReportThreshold.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+/**
+ * ReportThreshold.
+ *
+ * Per-reporter policy controlling which dispatch decisions actually trigger a
+ * notification for that reporter.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+enum ReportThreshold: string
+{
+    case Always = 'always';
+    case Unhealthy = 'unhealthy';
+    case StateChange = 'state-change';
+
+    public static function fromConfigValue(string $value): self
+    {
+        return self::tryFrom($value) ?? self::Unhealthy;
+    }
+}

--- a/Classes/Reporter/Reporter.php
+++ b/Classes/Reporter/Reporter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Reporter.
+ *
+ * A push channel that delivers monitoring status (email, Slack, Teams, …).
+ * Register a custom reporter by implementing this interface — the
+ * {@see \Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag}
+ * makes it discoverable automatically.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[AutoconfigureTag(name: 'monitoring.reporter')]
+interface Reporter
+{
+    public function isActive(): bool;
+
+    /**
+     * Which dispatch decisions this reporter wants to be notified about.
+     */
+    public function getThreshold(): ReportThreshold;
+
+    /**
+     * Delivers the report. Returns true only if the notification was sent
+     * successfully; returning false makes the dispatcher retry on the next run.
+     */
+    public function report(ReportContext $context): bool;
+
+    /**
+     * @return non-empty-string
+     */
+    public function getName(): string;
+
+    /**
+     * Static ::getPriority() used in the DI autowiring for sorting.
+     */
+    public static function getPriority(): int;
+}

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -4,17 +4,19 @@
 HTTP endpoint. The extension follows a provider-based architecture that makes it easy to extend with custom monitoring
 checks.
 
-The extension defines two main interfaces:
+The extension defines these main interfaces:
 
 - `MonitoringProvider`: For implementing monitoring checks, see [Provider Development](providers.md).
 - `Authorizer`: For implementing authorization strategies, see [Authorization](authorization.md).
+- `Reporter`: For pushing status to external channels, see [Reporter Development](reporters.md).
 
-Both interfaces support automatic service discovery through PHP attributes.
+All interfaces support automatic service discovery through PHP attributes.
 
 ## Further reading
 
 1. [Configuration](configuration.md)
 2. [Provider Development](providers.md)
 3. [Authorization](authorization.md)
-4. [API Reference](api.md)
-5. [Command-Line Interface](command-line.md)
+4. [Reporter Development](reporters.md)
+5. [API Reference](api.md)
+6. [Command-Line Interface](command-line.md)

--- a/Documentation/Reporter/EmailReporter.md
+++ b/Documentation/Reporter/EmailReporter.md
@@ -1,0 +1,55 @@
+# EmailReporter
+
+Sends the monitoring status by email through TYPO3's core mailer
+(`MailerInterface`). See [Reporters](../reporters.md) for the general dispatch
+flow and thresholds.
+
+## Configuration
+
+```php
+'EXTENSIONS' => [
+    'monitoring' => [
+        'reporter' => [
+            'mteu\Monitoring\Reporter\EmailReporter' => [
+                'enabled' => true,
+                'priority' => 10,
+                'threshold' => 'state-change',
+                'recipients' => 'ops@example.com, oncall@example.com',
+                'senderAddress' => 'typo3@example.com',
+                'subjectPrefix' => '[Monitoring]',
+            ],
+        ],
+    ],
+];
+```
+
+| Setting         | Default        | Notes                                                            |
+|-----------------|----------------|------------------------------------------------------------------|
+| `enabled`       | `false`        | Master switch.                                                   |
+| `priority`      | `10`           | Higher is reported first.                                        |
+| `threshold`     | `unhealthy`    | `always`, `unhealthy`, or `state-change`.                        |
+| `recipients`    | `''`           | Comma-separated addresses. **Required** — empty means inactive.  |
+| `senderAddress` | `''`           | Blank falls back to TYPO3's `defaultMailFromAddress`.            |
+| `subjectPrefix` | `[Monitoring]` | Prepended to every subject; blank for none.                      |
+
+The reporter is **active** only when `enabled` is `true` *and* at least one
+recipient is configured.
+
+## Transport
+
+SMTP / transport credentials are **not** part of this extension's
+configuration — they come from TYPO3's global `MAIL` settings
+(`$GLOBALS['TYPO3_CONF_VARS']['MAIL']`). A transport failure is logged and
+`report()` returns `false`, so the dispatcher retries on the next run.
+
+## Message
+
+Subject and body vary by decision:
+
+| Decision    | Subject (after prefix)         | Body opening                                          |
+|-------------|--------------------------------|------------------------------------------------------|
+| `Unhealthy` | `Unhealthy: <names>`           | The following services are reporting an unhealthy state: |
+| `Reminder`  | `Still unhealthy: <names>`     | The following services are still reporting an unhealthy state: |
+| `Recovered` | `All monitored services recovered` | All monitored services are healthy again.        |
+
+The body then lists every active provider as `[OK] Name` / `[FAILED] Name — reason`.

--- a/Documentation/reporters.md
+++ b/Documentation/reporters.md
@@ -1,0 +1,102 @@
+# Reporter Development Guide
+
+Reporters **push** monitoring status out (email, Slack, Teams, …) for setups
+where no external system scrapes the [HTTP endpoint](api.md). They are
+evaluated by the `ReportDispatcher`, which is triggered on demand via the
+`monitoring:report` CLI command (cron-friendly), not on every request.
+
+Reporters are auto-discovered via `#[AutoconfigureTag('monitoring.reporter')]`.
+
+## The dispatch flow
+
+On each run the dispatcher:
+
+1. executes all active providers and builds the current failure set;
+2. compares it against the persisted state (the dedup state machine) and
+   produces a single `NotificationDecision`:
+   - `Unhealthy` — a new outage or a *changed* failure set (notify now);
+   - `Reminder` — same failure set, reminder interval elapsed;
+   - `Recovered` — status returned to healthy after an outage (one-off);
+   - `None` — nothing to send (healthy, or throttled within the interval);
+3. fans the decision out to every active reporter whose **threshold** accepts it.
+
+State lives in a dedicated `typo3_monitoring_notification` cache that is
+deliberately outside the `system` cache group, so flushing system caches
+cannot make the dispatcher forget it already alerted. A failed delivery does
+not advance the reminder clock, so it is retried on the next run.
+
+See [Configuration](configuration.md) for the `reportDispatcher` settings
+(`reminderInterval`, `notifyOnRecovery`, `failOpenOnMissingState`).
+
+## Thresholds
+
+Each reporter declares which decisions it wants via `ReportThreshold`:
+
+| Threshold      | Receives                          |
+|----------------|-----------------------------------|
+| `always`       | `Unhealthy`, `Reminder`, `Recovered` |
+| `unhealthy`    | `Unhealthy`, `Reminder`           |
+| `state-change` | `Unhealthy`, `Recovered`          |
+
+## Custom Reporter
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace My\Extension\Reporter;
+
+use mteu\Monitoring\Reporter\Reporter;
+use mteu\Monitoring\Reporter\ReportContext;
+use mteu\Monitoring\Reporter\ReportThreshold;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('monitoring.reporter')]
+final class MyReporter implements Reporter
+{
+    public function isActive(): bool
+    {
+        return true; // e.g. enabled && credentials present
+    }
+
+    public function getThreshold(): ReportThreshold
+    {
+        return ReportThreshold::Unhealthy;
+    }
+
+    public function report(ReportContext $context): bool
+    {
+        // $context->decision, ->results, ->unhealthyProviderNames, ->isHealthy()
+        // Return true only when delivery succeeded; false makes the
+        // dispatcher retry on the next run.
+        return $this->send((string)$context->decision->name);
+    }
+
+    public function getName(): string
+    {
+        return 'MyReporter';
+    }
+
+    public static function getPriority(): int
+    {
+        return 0; // higher is reported first
+    }
+
+    private function send(string $payload): bool
+    {
+        // Your delivery logic
+        return true;
+    }
+}
+```
+
+## Built-in Reporters
+
+- **EmailReporter**: sends status via TYPO3's mailer, see [EmailReporter](Reporter/EmailReporter.md).
+
+## Best Practices
+
+- Return `false` from `report()` on delivery failure so it is retried.
+- Keep credentials out of extension configuration (use TYPO3's `MAIL`
+  settings, the Webhooks module, secrets, …).
+- Pick the narrowest threshold that fits the channel to avoid noise.

--- a/Tests/Functional/Command/ReportCommandTest.php
+++ b/Tests/Functional/Command/ReportCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Functional\Command;
+
+use mteu\Monitoring\Cache\NotificationStateCacheManager;
+use mteu\Monitoring\Command\ReportCommand;
+use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Reporter\ReportDispatcher;
+use mteu\Monitoring\Tests\Functional\Fixtures\ConfigurableProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * ReportCommandTest.
+ *
+ * Drives the command end-to-end against the real DI services and the
+ * database-backed notification cache, walking a full status lifecycle
+ * (healthy → unhealthy → still unhealthy → recovered) so the command's
+ * output reflects the persisted dedup state, not just an isolated decision.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ReportCommand::class)]
+final class ReportCommandTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'monitoring',
+        'typed_extconf',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'caching' => [
+                'cacheConfigurations' => [
+                    'typo3_monitoring' => [
+                        'frontend' => 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend',
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                        'options' => [],
+                        'groups' => ['system'],
+                    ],
+                    'typo3_monitoring_notification' => [
+                        'frontend' => 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend',
+                        'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\Typo3DatabaseBackend',
+                        'options' => [],
+                        'groups' => [],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    private const int REMINDER_INTERVAL = 100;
+
+    private NotificationStateCacheManager $stateStore;
+    private MonitoringExecutionHandler $executionHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stateStore = $this->get(NotificationStateCacheManager::class);
+        $this->executionHandler = $this->get(MonitoringExecutionHandler::class);
+
+        // Guarantee a clean dedup state per test.
+        $this->get(CacheManager::class)->getCache('typo3_monitoring_notification')->flush();
+    }
+
+    #[Test]
+    public function reportsNoNotificationWhenAllProvidersAreHealthy(): void
+    {
+        $tester = $this->runReport([new ConfigurableProvider('alpha', healthy: true)], 1_000);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('No notification dispatched.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsUnhealthyStatusOnFirstFailure(): void
+    {
+        $tester = $this->runReport([new ConfigurableProvider('alpha', healthy: false)], 1_000);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('Dispatched: unhealthy status.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsReminderWhenStillUnhealthyAfterInterval(): void
+    {
+        $provider = new ConfigurableProvider('alpha', healthy: false);
+
+        $this->runReport([$provider], 1_000);
+        $tester = $this->runReport([$provider], 1_000 + self::REMINDER_INTERVAL);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('Dispatched: reminder for ongoing unhealthy status.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsRecoveryWhenStatusReturnsToHealthy(): void
+    {
+        $provider = new ConfigurableProvider('alpha', healthy: false);
+
+        $this->runReport([$provider], 1_000);
+
+        $provider->setHealthy(true);
+        $tester = $this->runReport([$provider], 1_005);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+        self::assertStringContainsString('Dispatched: recovery notice.', $tester->getDisplay());
+    }
+
+    /**
+     * Builds and runs a fresh command at the given wall-clock timestamp so the
+     * dedup state machine sees advancing time across runs within one test.
+     *
+     * @param list<ConfigurableProvider> $providers
+     */
+    private function runReport(array $providers, int $timestamp): CommandTester
+    {
+        $context = new Context();
+        $context->setAspect('date', new DateTimeAspect((new \DateTimeImmutable())->setTimestamp($timestamp)));
+
+        $dispatcher = new ReportDispatcher(
+            $providers,
+            [], // the command's output reflects the decision regardless of reporters
+            $this->executionHandler,
+            $this->stateStore,
+            new MonitoringConfiguration(
+                new TokenAuthorizerConfiguration(),
+                new AdminUserAuthorizerConfiguration(),
+                new EmailReporterConfiguration(),
+                new ReportDispatcherConfiguration(reminderInterval: self::REMINDER_INTERVAL),
+            ),
+            $context,
+            new NullLogger(),
+        );
+
+        $tester = new CommandTester(new ReportCommand($dispatcher));
+        $tester->execute([]);
+
+        return $tester;
+    }
+}

--- a/Tests/Functional/Fixtures/ConfigurableProvider.php
+++ b/Tests/Functional/Fixtures/ConfigurableProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Functional\Fixtures;
+
+use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Result\MonitoringResult;
+use mteu\Monitoring\Result\Result;
+
+/**
+ * ConfigurableProvider.
+ *
+ * Test provider whose health/active state can be toggled at runtime.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final class ConfigurableProvider implements MonitoringProvider
+{
+    public function __construct(
+        /** @var non-empty-string $identifier */
+        private readonly string $identifier,
+        private bool $healthy = true,
+        private bool $active = true,
+    ) {}
+
+    public function setHealthy(bool $healthy): void
+    {
+        $this->healthy = $healthy;
+    }
+
+    public function getName(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getDescription(): string
+    {
+        return 'Configurable provider for reporter dispatcher tests';
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function execute(): Result
+    {
+        return new MonitoringResult($this->identifier, $this->healthy);
+    }
+}

--- a/Tests/Functional/Fixtures/RecordingReporter.php
+++ b/Tests/Functional/Fixtures/RecordingReporter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Functional\Fixtures;
+
+use mteu\Monitoring\Reporter\ReportContext;
+use mteu\Monitoring\Reporter\Reporter;
+use mteu\Monitoring\Reporter\ReportThreshold;
+
+/**
+ * RecordingReporter.
+ *
+ * Captures every {@see ReportContext} it is handed so tests can assert when
+ * (and how often) the dispatcher decided to notify.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final class RecordingReporter implements Reporter
+{
+    /** @var list<ReportContext> */
+    private array $received = [];
+
+    public function __construct(
+        private readonly ReportThreshold $threshold = ReportThreshold::Unhealthy,
+        private readonly bool $active = true,
+        private readonly bool $deliverSuccessfully = true,
+    ) {}
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function getThreshold(): ReportThreshold
+    {
+        return $this->threshold;
+    }
+
+    public function report(ReportContext $context): bool
+    {
+        $this->received[] = $context;
+
+        return $this->deliverSuccessfully;
+    }
+
+    public function receivedCount(): int
+    {
+        return count($this->received);
+    }
+
+    public function getName(): string
+    {
+        return 'RecordingReporter';
+    }
+
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+}

--- a/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Functional/Middleware/MonitoringMiddlewareTest.php
@@ -21,6 +21,8 @@ use mteu\Monitoring\Authorization\Authorizer;
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Middleware\MonitoringMiddleware;
 use mteu\Monitoring\Provider\MonitoringProvider;
@@ -289,12 +291,11 @@ final class MonitoringMiddlewareTest extends FunctionalTestCase
 
     private function createConfiguration(string $endpoint, bool $enforceHttps = false): MonitoringConfiguration
     {
-        $tokenAuthorizerConfig = new TokenAuthorizerConfiguration();
-        $adminUserAuthorizerConfig = new AdminUserAuthorizerConfiguration();
-
         return new MonitoringConfiguration(
-            $tokenAuthorizerConfig,
-            $adminUserAuthorizerConfig,
+            new TokenAuthorizerConfiguration(),
+            new AdminUserAuthorizerConfiguration(),
+            new EmailReporterConfiguration(),
+            new ReportDispatcherConfiguration(),
             $endpoint,
             $enforceHttps,
         );

--- a/Tests/Unit/Authorization/AdminUserAuthorizerTest.php
+++ b/Tests/Unit/Authorization/AdminUserAuthorizerTest.php
@@ -21,6 +21,8 @@ use mteu\Monitoring\Authorization\AdminUserAuthorizer;
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use PHPUnit\Framework;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -131,6 +133,8 @@ final class AdminUserAuthorizerTest extends Framework\TestCase
                 enabled: $enabled,
                 priority: -10,
             ),
+            emailReporterConfiguration: new EmailReporterConfiguration(),
+            reporterDispatcherConfiguration: new ReportDispatcherConfiguration(),
             endpoint: '/monitor/health',
         );
 

--- a/Tests/Unit/Authorization/TokenAuthorizerTest.php
+++ b/Tests/Unit/Authorization/TokenAuthorizerTest.php
@@ -21,6 +21,8 @@ use mteu\Monitoring\Authorization\TokenAuthorizer;
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use PHPUnit\Framework;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -146,6 +148,8 @@ final class TokenAuthorizerTest extends Framework\TestCase
                 authHeaderName: $authHeaderName,
             ),
             adminUserAuthorizerConfiguration: new AdminUserAuthorizerConfiguration(),
+            emailReporterConfiguration: new EmailReporterConfiguration(),
+            reporterDispatcherConfiguration: new ReportDispatcherConfiguration(),
             endpoint: $endpoint,
         );
 

--- a/Tests/Unit/Cache/MonitoringCacheManagerTest.php
+++ b/Tests/Unit/Cache/MonitoringCacheManagerTest.php
@@ -21,6 +21,8 @@ use mteu\Monitoring\Cache\MonitoringCacheManager;
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use mteu\Monitoring\Result\CachedMonitoringResult;
 use mteu\Monitoring\Result\MonitoringResult;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -154,6 +156,8 @@ final class MonitoringCacheManagerTest extends TestCase
         return new MonitoringConfiguration(
             new TokenAuthorizerConfiguration(true, 10, 'secret', 'X-TYPO3-MONITORING-AUTH'),
             new AdminUserAuthorizerConfiguration(),
+            new EmailReporterConfiguration(),
+            new ReportDispatcherConfiguration(),
             cacheDefaultLifetime: $cacheDefaultLifetime,
         );
     }

--- a/Tests/Unit/Command/ReportCommandTest.php
+++ b/Tests/Unit/Command/ReportCommandTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Command;
+
+use mteu\Monitoring\Cache\MonitoringCacheManager;
+use mteu\Monitoring\Cache\NotificationStateCacheManager;
+use mteu\Monitoring\Command\ReportCommand;
+use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
+use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
+use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Reporter\ReportDispatcher;
+use mteu\Monitoring\Result\MonitoringResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
+
+/**
+ * ReportCommandTest.
+ *
+ * Pins the command's only responsibility: translating each dispatcher
+ * {@see \mteu\Monitoring\Reporter\NotificationDecision} into the matching
+ * console line while always exiting with {@see Command::SUCCESS}. The real
+ * dispatcher is driven through an in-memory notification cache so every
+ * decision branch is reachable without a database.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(ReportCommand::class)]
+final class ReportCommandTest extends TestCase
+{
+    private const int REMINDER_INTERVAL = 100;
+
+    /**
+     * Shared in-memory notification state, so dispatcher runs within a single
+     * test observe each other's persisted state.
+     *
+     * @var array<string, mixed>
+     */
+    private array $notificationCache = [];
+
+    #[Test]
+    public function commandIsRegisteredWithExpectedNameAndDescription(): void
+    {
+        $command = $this->createCommand([], 1_000);
+
+        self::assertSame('monitoring:report', $command->getName());
+        self::assertSame(
+            'Evaluates monitoring status and dispatches push notifications to active reporters.',
+            $command->getDescription(),
+        );
+    }
+
+    #[Test]
+    public function reportsNoNotificationWhenEverythingIsHealthy(): void
+    {
+        $tester = new CommandTester($this->createCommand([$this->provider('alpha', healthy: true)], 1_000));
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No notification dispatched.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsUnhealthyStatusOnFirstFailure(): void
+    {
+        $tester = new CommandTester($this->createCommand([$this->provider('alpha', healthy: false)], 1_000));
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dispatched: unhealthy status.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsReminderWhenStillUnhealthyAfterInterval(): void
+    {
+        $this->createTester([$this->provider('alpha', healthy: false)], 1_000)->execute([]);
+
+        $tester = $this->createTester([$this->provider('alpha', healthy: false)], 1_000 + self::REMINDER_INTERVAL);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dispatched: reminder for ongoing unhealthy status.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsRecoveryAfterReturningToHealthy(): void
+    {
+        $this->createTester([$this->provider('alpha', healthy: false)], 1_000)->execute([]);
+
+        $tester = $this->createTester([$this->provider('alpha', healthy: true)], 1_005);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dispatched: recovery notice.', $tester->getDisplay());
+    }
+
+    /**
+     * @param list<MonitoringProvider> $providers
+     */
+    private function createTester(array $providers, int $timestamp): CommandTester
+    {
+        return new CommandTester($this->createCommand($providers, $timestamp));
+    }
+
+    /**
+     * @param list<MonitoringProvider> $providers
+     */
+    private function createCommand(array $providers, int $timestamp): ReportCommand
+    {
+        $context = new Context();
+        $context->setAspect('date', new DateTimeAspect((new \DateTimeImmutable())->setTimestamp($timestamp)));
+
+        $dispatcher = new ReportDispatcher(
+            $providers,
+            [], // reporters are irrelevant to the command's decision-to-output mapping
+            new MonitoringExecutionHandler(new MonitoringCacheManager(new CacheManager())),
+            new NotificationStateCacheManager($this->inMemoryCacheManager()),
+            new MonitoringConfiguration(
+                new TokenAuthorizerConfiguration(),
+                new AdminUserAuthorizerConfiguration(),
+                new EmailReporterConfiguration(),
+                new ReportDispatcherConfiguration(reminderInterval: self::REMINDER_INTERVAL),
+            ),
+            $context,
+            new NullLogger(),
+        );
+
+        return new ReportCommand($dispatcher);
+    }
+
+    /**
+     * A CacheManager whose notification cache lives in process memory, so the
+     * dedup state machine can persist and reload state between dispatcher runs.
+     */
+    private function inMemoryCacheManager(): CacheManager
+    {
+        $frontend = self::createStub(FrontendInterface::class);
+        $frontend->method('has')->willReturnCallback(
+            fn(string $entry): bool => array_key_exists($entry, $this->notificationCache),
+        );
+        $frontend->method('get')->willReturnCallback(
+            fn(string $entry): mixed => $this->notificationCache[$entry] ?? false,
+        );
+        $frontend->method('set')->willReturnCallback(
+            function (string $entry, mixed $variable): void {
+                $this->notificationCache[$entry] = $variable;
+            },
+        );
+
+        $cacheManager = self::createStub(CacheManager::class);
+        $cacheManager->method('getCache')->willReturn($frontend);
+
+        return $cacheManager;
+    }
+
+    private function provider(string $name, bool $healthy): MonitoringProvider
+    {
+        return new readonly class ($name, $healthy) implements MonitoringProvider {
+            public function __construct(
+                private string $name,
+                private bool $healthy,
+            ) {}
+
+            public function getName(): string
+            {
+                assert($this->name !== '');
+
+                return $this->name;
+            }
+
+            public function getDescription(): string
+            {
+                return '';
+            }
+
+            public function isActive(): bool
+            {
+                return true;
+            }
+
+            public function execute(): MonitoringResult
+            {
+                return new MonitoringResult($this->name, $this->healthy);
+            }
+        };
+    }
+}

--- a/Tests/Unit/Configuration/MonitoringConfigurationTest.php
+++ b/Tests/Unit/Configuration/MonitoringConfigurationTest.php
@@ -20,6 +20,8 @@ namespace mteu\Monitoring\Tests\Unit\Configuration;
 use mteu\Monitoring\Configuration\Authorizer\AdminUserAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\Authorizer\TokenAuthorizerConfiguration;
 use mteu\Monitoring\Configuration\MonitoringConfiguration;
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use PHPUnit\Framework;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -75,6 +77,8 @@ final class MonitoringConfigurationTest extends Framework\TestCase
         return new MonitoringConfiguration(
             new TokenAuthorizerConfiguration(),
             new AdminUserAuthorizerConfiguration(),
+            new EmailReporterConfiguration(),
+            new ReportDispatcherConfiguration(),
         );
     }
 
@@ -83,6 +87,8 @@ final class MonitoringConfigurationTest extends Framework\TestCase
         return new MonitoringConfiguration(
             new TokenAuthorizerConfiguration(),
             new AdminUserAuthorizerConfiguration(),
+            new EmailReporterConfiguration(),
+            new ReportDispatcherConfiguration(),
             $endpoint,
         );
     }

--- a/Tests/Unit/Configuration/Reporter/EmailReporterConfigurationTest.php
+++ b/Tests/Unit/Configuration/Reporter/EmailReporterConfigurationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Configuration\Reporter;
+
+use mteu\Monitoring as Src;
+use mteu\Monitoring\Reporter\ReportThreshold;
+use PHPUnit\Framework;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * EmailReporterConfigurationTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Configuration\Reporter\EmailReporterConfiguration::class)]
+final class EmailReporterConfigurationTest extends Framework\TestCase
+{
+    #[Test]
+    public function defaultValuesAreCorrect(): void
+    {
+        $subject = new Src\Configuration\Reporter\EmailReporterConfiguration();
+
+        self::assertFalse($subject->isEnabled());
+        self::assertSame(10, $subject->getPriority());
+        self::assertSame(ReportThreshold::Unhealthy, $subject->getThreshold());
+        self::assertSame([], $subject->getRecipients());
+        self::assertSame('[Monitoring]', $subject->subjectPrefix);
+        self::assertInstanceOf(Src\Configuration\Reporter\ReporterConfiguration::class, $subject);
+    }
+
+    #[Test]
+    #[Framework\Attributes\DataProvider('thresholdDataProvider')]
+    public function thresholdMapsFromConfigValue(string $configValue, ReportThreshold $expected): void
+    {
+        $subject = new Src\Configuration\Reporter\EmailReporterConfiguration(threshold: $configValue);
+
+        self::assertSame($expected, $subject->getThreshold());
+    }
+
+    #[Test]
+    public function recipientsAreSplitAndTrimmed(): void
+    {
+        $subject = new Src\Configuration\Reporter\EmailReporterConfiguration(
+            recipients: ' a@example.com , ,b@example.com ',
+        );
+
+        self::assertSame(['a@example.com', 'b@example.com'], $subject->getRecipients());
+    }
+
+    /**
+     * @return \Generator<string, array{string, ReportThreshold}>
+     */
+    public static function thresholdDataProvider(): \Generator
+    {
+        yield 'always' => ['always', ReportThreshold::Always];
+        yield 'unhealthy' => ['unhealthy', ReportThreshold::Unhealthy];
+        yield 'state-change' => ['state-change', ReportThreshold::StateChange];
+        yield 'invalid falls back to unhealthy' => ['nonsense', ReportThreshold::Unhealthy];
+    }
+}

--- a/Tests/Unit/Reporter/EmailReporterTest.php
+++ b/Tests/Unit/Reporter/EmailReporterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Unit\Reporter;
+
+use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
+use mteu\Monitoring\Reporter\EmailReporter;
+use mteu\Monitoring\Reporter\NotificationDecision;
+use mteu\Monitoring\Reporter\ReportContext;
+use mteu\Monitoring\Reporter\ReportThreshold;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Mail\MailerInterface;
+
+/**
+ * EmailReporterTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(EmailReporter::class)]
+final class EmailReporterTest extends TestCase
+{
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function isInactiveWhenDisabled(): void
+    {
+        self::assertFalse(
+            $this->reporter(enabled: false, recipients: 'ops@example.com')->isActive(),
+        );
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function isInactiveWhenNoRecipients(): void
+    {
+        self::assertFalse(
+            $this->reporter(enabled: true, recipients: '')->isActive(),
+        );
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function isActiveWhenEnabledWithRecipients(): void
+    {
+        $reporter = $this->reporter(enabled: true, recipients: 'ops@example.com');
+
+        self::assertTrue($reporter->isActive());
+        self::assertSame('EmailReporter', $reporter->getName());
+        self::assertSame(ReportThreshold::Unhealthy, $reporter->getThreshold());
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function reportReturnsFalseWithoutRecipients(): void
+    {
+        $reporter = $this->reporter(enabled: true, recipients: '');
+
+        $context = new ReportContext(NotificationDecision::Unhealthy, [], ['svc'], 'fp');
+
+        self::assertFalse($reporter->report($context));
+    }
+
+    private function reporter(bool $enabled, string $recipients): EmailReporter
+    {
+        return new EmailReporter(
+            new EmailReporterConfiguration(enabled: $enabled, recipients: $recipients),
+            $this->createMock(MailerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
 		"psr/log": "^3.0",
 		"symfony/console": "^7.3",
 		"symfony/dependency-injection": "^7.3",
+		"symfony/mailer": "^7.4",
+		"symfony/mime": "^7.4",
 		"typo3/cms-backend": "^13.4.23 || ^14.3.0",
 		"typo3/cms-core": "^13.4.23 || ^14.3.0",
 		"typo3fluid/fluid": "^2.15.0 || ^4.3 || ^5.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "472f78c29f6972099c8bd9a165396ce8",
+    "content-hash": "acf772a9717fca56694ec54834a026b2",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -28,3 +28,29 @@ authorizer {
         priority=-10
     }
 }
+
+reportDispatcher {
+    # cat=ReportDispatcher/ReminderInterval//10; type=int+; label=Reminder interval (seconds):Minimum seconds between repeated notifications for an unchanged failure set. Default 86400 (once per day). A changed failure set always notifies immediately.
+    reminderInterval=86400
+    # cat=ReportDispatcher/NotifyOnRecovery//20; type=boolean; label=Notify on recovery:Send a one-off notification when status returns to healthy after an outage.
+    notifyOnRecovery=1
+    # cat=ReportDispatcher/FailOpen//30; type=boolean; label=Fail-open on missing state:If notification state is absent (e.g. cache flushed) while status is unhealthy, send (fail-open) rather than stay silent.
+    failOpenOnMissingState=1
+}
+
+reporter {
+    mteu\Monitoring\Reporter\EmailReporter {
+        # cat=EmailReporter/Enabled//10; type=boolean; label=Enable EmailReporter:Send monitoring reports via TYPO3's mailer (transport configured in MAIL settings).
+        enabled=0
+        # cat=EmailReporter/Priority//20; type=string; label=Priority:Higher value is reported first.
+        priority=10
+        # cat=EmailReporter/Threshold//30; type=options[Always=always,Unhealthy only=unhealthy,On state change=state-change]; label=Threshold:When this reporter should send.
+        threshold=state-change
+        # cat=EmailReporter/Recipients//40; type=string; label=Recipients:Comma-separated list of recipient email addresses.
+        recipients=
+        # cat=EmailReporter/Sender//50; type=string; label=Sender address:Leave blank to use TYPO3's defaultMailFromAddress.
+        senderAddress=
+        # cat=EmailReporter/SubjectPrefix//60; type=string; label=Subject prefix
+        subjectPrefix=[Monitoring]
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,3 +23,15 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
         'groups' => ['system'],
     ];
 }
+
+// Notification dedup state. Intentionally NOT in the 'system' group so that
+// routine "flush system caches" / provider-cache-flush actions cannot make
+// the reporter forget it already alerted (and re-notify on the next run).
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3_monitoring_notification'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3_monitoring_notification'] = [
+        'frontend' => TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
+        'backend' => TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class,
+        'options' => [],
+        'groups' => [],
+    ];
+}


### PR DESCRIPTION
Introducing `Reporters` that push the monitoring status (email, Slack, Teams, …) for setups where no external system scrapes the HTTP endpoint.

They are evaluated by the `ReportDispatcher`, which is currently triggered on demand via the `monitoring:report` CLI command, not on every request.

--
A scheduler task to collect status and pushes on its own will be provided with version 1.0, too.