### PR TITLE
[FEATURE] Add `MonitoringReportTask`

### DIFF
--- a/Classes/Provider/Scheduler/SchedulerTaskLinkBuilder.php
+++ b/Classes/Provider/Scheduler/SchedulerTaskLinkBuilder.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace mteu\Monitoring\Provider\Scheduler;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;

--- a/Classes/Reporter/ReportDispatcher.php
+++ b/Classes/Reporter/ReportDispatcher.php
@@ -23,6 +23,7 @@ use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Provider\MonitoringProvider;
 use mteu\Monitoring\Result\Result;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use TYPO3\CMS\Core\Context\Context;
 
@@ -36,6 +37,7 @@ use TYPO3\CMS\Core\Context\Context;
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
  */
+#[Autoconfigure(public: true)]
 final readonly class ReportDispatcher
 {
     public function __construct(

--- a/Classes/Task/MonitoringReportTask.php
+++ b/Classes/Task/MonitoringReportTask.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Task;
+
+use mteu\Monitoring\Reporter\ReportDispatcher;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+
+/**
+ * MonitoringReportTask.
+ *
+ * Backend Scheduler trigger for the push reporters. Thin shell delegating
+ * to {@see ReportDispatcher} so it stays identical to the cron-friendly
+ * {@see \mteu\Monitoring\Command\ReportCommand}. Scheduler tasks are not
+ * DI-constructed in v13/14, so the dispatcher is resolved via the container
+ * at runtime.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final class MonitoringReportTask extends AbstractTask
+{
+    public function execute(): bool
+    {
+        GeneralUtility::makeInstance(ReportDispatcher::class)->dispatch();
+
+        return true;
+    }
+}

--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 use Composer\Autoload;
 use ShipMonk\ComposerDependencyAnalyser;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 $rootPath = dirname(__DIR__, 2);
 
@@ -29,6 +30,13 @@ $configuration
     ->addPathsToExclude([
         $rootPath . '/Tests/CGL',
     ])
+    // typo3/cms-scheduler is an intentional *optional* integration: it's a
+    // composer "suggest" (require-dev for CI), and MonitoringReportTask is
+    // guarded by class_exists() in ext_localconf.php.
+    ->ignoreErrorsOnPackage(
+        'typo3/cms-scheduler',
+        [ErrorType::DEV_DEPENDENCY_IN_PROD],
+    )
 ;
 
 return $configuration;

--- a/Tests/CGL/phpstan.neon
+++ b/Tests/CGL/phpstan.neon
@@ -6,6 +6,7 @@ parameters:
 		- ../../.build/vendor/eliashaeussler/phpunit-attributes/src
 		- ../../.build/vendor/phpunit/phpunit/src
 		- ../../.build/vendor/typo3/cms-backend/Classes
+		- ../../.build/vendor/typo3/cms-scheduler/Classes
 		- ../../.build/vendor/typo3/testing-framework/Classes
 		- ../../.build/vendor/mteu/typo3-typed-extconf/Classes
 	paths:
@@ -21,6 +22,7 @@ parameters:
 			classesAllowedToBeExtended:
 				- Exception
 				- Symfony\Component\Console\Command\Command
+				- TYPO3\CMS\Scheduler\Task\AbstractTask
 				- TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper
 				- TYPO3\TestingFramework\Core\Functional\FunctionalTestCase
 				- TYPO3\TestingFramework\Core\Unit\UnitTestCase

--- a/Tests/Functional/Task/MonitoringReportTaskTest.php
+++ b/Tests/Functional/Task/MonitoringReportTaskTest.php
@@ -17,10 +17,13 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Tests\Functional\Task;
 
+use EliasHaeussler\PHPUnitAttributes\Attribute\RequiresPackage;
 use mteu\Monitoring\Task\MonitoringReportTask;
 use mteu\Monitoring\Tests\Functional\MonitoringFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Scheduler\Service\TaskService;
 
 /**
  * MonitoringReportTaskTest.
@@ -45,18 +48,44 @@ final class MonitoringReportTaskTest extends MonitoringFunctionalTestCase
         self::assertTrue($task->execute());
     }
 
+    /**
+     * Proves the task is actually discoverable by the Scheduler's own registry
+     * (i.e. registered under the key the scheduler reads), not merely that we
+     * wrote some array key ourselves.
+     */
     #[Test]
-    public function taskIsRegisteredWithScheduler(): void
+    #[RequiresPackage('typo3/cms-scheduler', '>= 14')]
+    public function taskIsDiscoverableByTheScheduler(): void
     {
-        $vars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
-        self::assertIsArray($vars);
+        $taskService = $this->getTaskService();
+        self::assertTrue($taskService->isTaskTypeRegistered(MonitoringReportTask::class));
+    }
 
-        $scheduler = $vars['SCHEDULER'] ?? null;
-        self::assertIsArray($scheduler);
+    /**
+     * v13 counterpart: the public discovery API is {@see TaskService::getAvailableTaskTypes()}
+     * (made protected in v14, hence the reflection call to keep static analysis against v14 happy).
+     */
+    #[Test]
+    #[RequiresPackage('typo3/cms-scheduler', '< 14')]
+    public function taskIsDiscoverableByTheSchedulerOnV13(): void
+    {
+        $taskService = $this->getTaskService();
 
-        $tasks = $scheduler['tasks'] ?? null;
-        self::assertIsArray($tasks);
+        // v13's getAvailableTaskTypes() localizes task titles via $GLOBALS['LANG']
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
 
-        self::assertArrayHasKey(MonitoringReportTask::class, $tasks);
+        $taskTypes = (new \ReflectionMethod($taskService, 'getAvailableTaskTypes'))->invoke($taskService);
+
+        self::assertIsArray($taskTypes);
+        self::assertArrayHasKey(MonitoringReportTask::class, $taskTypes);
+    }
+
+    private function getTaskService(): TaskService
+    {
+
+        $taskService = $this->get(TaskService::class);
+        self::assertInstanceOf(TaskService::class, $taskService);
+
+        return $taskService;
     }
 }

--- a/Tests/Functional/Task/MonitoringReportTaskTest.php
+++ b/Tests/Functional/Task/MonitoringReportTaskTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Tests\Functional\Task;
+
+use mteu\Monitoring\Task\MonitoringReportTask;
+use mteu\Monitoring\Tests\Functional\MonitoringFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * MonitoringReportTaskTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+#[CoversClass(MonitoringReportTask::class)]
+final class MonitoringReportTaskTest extends MonitoringFunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'scheduler',
+    ];
+
+    #[Test]
+    public function executeDelegatesToDispatcherAndReturnsTrue(): void
+    {
+        $task = new MonitoringReportTask();
+
+        // With no recipients/webhook configured the dispatcher returns
+        // NotificationDecision::None and the task should still succeed.
+        self::assertTrue($task->execute());
+    }
+
+    #[Test]
+    public function taskIsRegisteredWithScheduler(): void
+    {
+        $vars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        self::assertIsArray($vars);
+
+        $scheduler = $vars['SCHEDULER'] ?? null;
+        self::assertIsArray($scheduler);
+
+        $tasks = $scheduler['tasks'] ?? null;
+        self::assertIsArray($tasks);
+
+        self::assertArrayHasKey(MonitoringReportTask::class, $tasks);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -35,3 +35,14 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
         'groups' => [],
     ];
 }
+
+// Optional integration with the TYPO3 Scheduler. Guarded so the extension still
+// installs and the CLI path (monitoring:report) keeps working without the
+// typo3/cms-scheduler system extension.
+if (class_exists(\TYPO3\CMS\Scheduler\Task\AbstractTask::class)) {
+    $GLOBALS['TYPO3_CONF_VARS']['SCHEDULER']['tasks'][\mteu\Monitoring\Task\MonitoringReportTask::class] = [
+        'extension' => 'monitoring',
+        'title' => 'Monitoring: Dispatch Reporters',
+        'description' => 'Evaluates monitoring status and dispatches push notifications to active reporters.',
+    ];
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -40,7 +40,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 // installs and the CLI path (monitoring:report) keeps working without the
 // typo3/cms-scheduler system extension.
 if (class_exists(\TYPO3\CMS\Scheduler\Task\AbstractTask::class)) {
-    $GLOBALS['TYPO3_CONF_VARS']['SCHEDULER']['tasks'][\mteu\Monitoring\Task\MonitoringReportTask::class] = [
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\mteu\Monitoring\Task\MonitoringReportTask::class] = [
         'extension' => 'monitoring',
         'title' => 'Monitoring: Dispatch Reporters',
         'description' => 'Evaluates monitoring status and dispatches push notifications to active reporters.',


### PR DESCRIPTION
Adds a thin `MonitoringReportTask` that delegates to `ReportDispatcher`, so operators can drive reporting from the TYPO3 backend Scheduler in addition to the existing `monitoring:report` CLI command. It is the backend counterpart already referenced by `ReportCommand`'s docblock.