### PR TITLE
[!!!][FEATURE] Introduce `isEnabled()` provider contract

### DIFF
--- a/Classes/Command/MonitoringCommand.php
+++ b/Classes/Command/MonitoringCommand.php
@@ -94,7 +94,7 @@ final class MonitoringCommand extends Command
         $outcomes = [];
 
         foreach ($this->monitoringProviders as $provider) {
-            if ($provider->isActive()) {
+            if ($provider->isEnabled() && $provider->isActive()) {
                 $outcomes[$provider::class] = $this->executionHandler->executeProviderWithMetadata(
                     $provider,
                     $useCache,

--- a/Classes/Middleware/MonitoringMiddleware.php
+++ b/Classes/Middleware/MonitoringMiddleware.php
@@ -178,7 +178,7 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
         $results = [];
 
         foreach ($this->monitoringProviders as $provider) {
-            if ($provider->isActive()) {
+            if ($provider->isEnabled() && $provider->isActive()) {
                 $results[$provider->getName()] = $this->executionHandler->executeProvider($provider);
             }
         }

--- a/Classes/Provider/MonitoringProvider.php
+++ b/Classes/Provider/MonitoringProvider.php
@@ -43,8 +43,13 @@ interface MonitoringProvider
     public function getDescription(): string;
 
     /**
-     * Allows your provider to implement the MonitoringProvider interface while being ignored for the actual monitoring.
+     * Whether an operator has switched this provider on. This reflects intent only
+     * — not runtime readiness. A provider can be enabled in configuration yet
+     * inactive when a technical precondition is unmet (a missing dependency, an
+     * unloaded extension).
      */
+    public function isEnabled(): bool;
+
     public function isActive(): bool;
 
     public function execute(): Result;

--- a/Classes/Provider/Scheduler/SchedulerProvider.php
+++ b/Classes/Provider/Scheduler/SchedulerProvider.php
@@ -69,12 +69,13 @@ final readonly class SchedulerProvider implements MonitoringProvider
             . 'Inactive when the scheduler extension is not installed.';
     }
 
+    public function isEnabled(): bool
+    {
+        return $this->configuration->isEnabled();
+    }
+
     public function isActive(): bool
     {
-        if (!$this->configuration->isEnabled()) {
-            return false;
-        }
-
         return ExtensionManagementUtility::isLoaded('scheduler');
     }
 

--- a/Classes/Reporter/ReportDispatcher.php
+++ b/Classes/Reporter/ReportDispatcher.php
@@ -205,7 +205,7 @@ final readonly class ReportDispatcher
         $results = [];
 
         foreach ($this->monitoringProviders as $provider) {
-            if ($provider->isActive()) {
+            if ($provider->isEnabled() && $provider->isActive()) {
                 $results[$provider->getName()] = $this->executionHandler->executeProvider($provider);
             }
         }

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -52,7 +52,14 @@ return [
 - **`priority`**: Authorization priority (default: `-10`)
 
 ### Providers
-- **`enabled`**: Enable/disable specific providers
+- **`enabled`**: Enable/disable specific providers.
+
+  A provider's on/off state is exposed through its `isEnabled()` method, which
+  acts as an authoritative kill-switch (a disabled provider is never executed).
+  How that value is sourced is up to each provider; the recommended approach is a
+  typed extension-configuration object, as the shipped `SchedulerProvider` does.
+  See [migration.md](migration_v1.md) and
+  [providers.md](providers.md#enablement-and-activation) for details.
 
 ## Configuration Access
 

--- a/Documentation/migration_v1.md
+++ b/Documentation/migration_v1.md
@@ -1,0 +1,110 @@
+# Migration Guide
+
+## Adding `isEnabled()` to `MonitoringProvider`
+
+The `MonitoringProvider` interface gains a new method:
+
+```php
+public function isEnabled(): bool;
+```
+
+This is a **breaking change** for custom providers: every class implementing
+`MonitoringProvider` (directly or via `CacheableMonitoringProvider`) must now
+provide an `isEnabled()` method. Providers shipped with the extension are already
+updated.
+
+### Why
+
+Previously a provider was either "on" or "off" through `isActive()` alone, which
+conflated two different questions:
+
+- **Should this provider run?** — operator intent (a configuration toggle).
+- **Can this provider run right now?** — runtime readiness (a dependency is
+  installed, an extension is loaded, …).
+
+Splitting them lets the backend show *enabled but not ready* as a configuration
+mismatch instead of silently hiding the provider, and gives operators a real
+kill-switch.
+
+### What changed at runtime
+
+`isEnabled()` is now an authoritative kill-switch. A provider runs only when
+
+```
+isEnabled() && isActive()
+```
+
+is true — on the health endpoint, the CLI command, and the reporter alike. A
+provider that returns `false` from `isEnabled()` is **never executed**, even if
+its `isActive()` returns `true`.
+
+### How to update your provider
+
+Implement `isEnabled()` to express operator intent, and (optionally) narrow
+`isActive()` to AND-in technical preconditions.
+
+**Minimal** — always on, behaves exactly as before:
+
+```php
+public function isEnabled(): bool
+{
+    return true;
+}
+
+// Keep your existing isActive(), or default it to isEnabled():
+public function isActive(): bool
+{
+    return $this->isEnabled();
+}
+```
+
+If your old `isActive()` already mixed in a precondition, keep that and gate it
+behind `isEnabled()`:
+
+```php
+// Before
+public function isActive(): bool
+{
+    return ExtensionManagementUtility::isLoaded('my_extension');
+}
+
+// After
+public function isEnabled(): bool
+{
+    return true; // or read your configuration — see below
+}
+
+public function isActive(): bool
+{
+    return $this->isEnabled()
+        && ExtensionManagementUtility::isLoaded('my_extension');
+}
+```
+
+### Where `isEnabled()` should read from
+
+That is your choice — a hardcoded `true`, an environment variable, a YAML/PHP
+settings file, a database flag, or extension configuration.
+
+**Recommended:** back it with a typed extension-configuration object so an
+operator can toggle the provider without a deployment in instances with a writable `settings.php`|`additional.php`. The shipped
+`SchedulerProvider` is the reference implementation:
+
+```php
+public function isEnabled(): bool
+{
+    return $this->configuration->isEnabled();
+}
+
+public function isActive(): bool
+{
+    return $this->isEnabled() && ExtensionManagementUtility::isLoaded('scheduler');
+}
+```
+
+Here `$this->configuration` is a typed object mapped from the extension
+configuration (`SchedulerProviderConfiguration`), keeping the configuration read
+in one strongly-typed place.
+
+See [providers.md](providers.md#enablement-and-activation) for the full
+enablement-vs-activation model.

--- a/Documentation/providers.md
+++ b/Documentation/providers.md
@@ -27,10 +27,24 @@ final class MyServiceProvider implements MonitoringProvider
         return 'Monitors my custom service';
     }
 
+    public function isEnabled(): bool
+    {
+        // Operator intent. Return true to be on by default, or back this with
+        // your own configuration so it can be toggled. A hardcoded `return true` is fine;
+        // otherwise back it with whatever fits your deployment — extension configuration,
+        // an environment variable, a YAML/PHP settings file, a database flag, daytime.
+        //
+        // Note: A provider whose `isEnabled()` returns `false` is never executed —
+        // not on the health endpoint, the CLI, nor the reporter — regardless of what `isActive()` returns.
+        return $this->configuration->isEnabled();
+    }
+
     public function isActive(): bool
     {
-        return true; // or conditional logic
-    }
+        // Enforce technical preconditions as needed or delegate to `isEnabled()` by returning true.
+        return
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('required_ext') &&
+            (Environment::getContext())->isProduction();
 
     public function execute(): Result
     {
@@ -104,6 +118,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
+/**
+ * Silly example since a missing DB connection would fail in bootstrapping already.
+ */
 #[AutoconfigureTag('monitoring.provider')]
 final class DatabaseConnectionProvider implements MonitoringProvider
 {
@@ -122,9 +139,14 @@ final class DatabaseConnectionProvider implements MonitoringProvider
         return 'Monitors database connectivity';
     }
 
+    public function isEnabled(): bool
+    {
+        return $extensionConfiguration->isEnabled();
+    }
+
     public function isActive(): bool
     {
-        return true;
+        return $this->isEnabled();
     }
 
     public function execute(): Result
@@ -177,9 +199,14 @@ final class MultiComponentProvider implements MonitoringProvider
         return 'Monitors multiple sub-components';
     }
 
-    public function isActive(): bool
+    public function isEnabled(): bool
     {
         return true;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isEnabled();
     }
 
     public function execute(): Result
@@ -218,19 +245,6 @@ final class MultiComponentProvider implements MonitoringProvider
         // Check component B logic
         return new MonitoringResult('ComponentB', true);
     }
-}
-```
-
-### Conditional Activation
-
-```php
-public function isActive(): bool
-{
-    // Only active if extension loaded
-    return ExtensionManagementUtility::isLoaded('my_extension');
-
-    // Or environment-specific
-    return GeneralUtility::getApplicationContext()->isProduction();
 }
 ```
 

--- a/Tests/Functional/Fixtures/CacheableProvider.php
+++ b/Tests/Functional/Fixtures/CacheableProvider.php
@@ -46,6 +46,11 @@ final class CacheableProvider implements CacheableMonitoringProvider
         return 'Test cacheable provider for functional tests';
     }
 
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
     public function isActive(): bool
     {
         return true;

--- a/Tests/Functional/Fixtures/ConfigurableProvider.php
+++ b/Tests/Functional/Fixtures/ConfigurableProvider.php
@@ -53,6 +53,11 @@ final class ConfigurableProvider implements MonitoringProvider
         return 'Configurable provider for reporter dispatcher tests';
     }
 
+    public function isEnabled(): bool
+    {
+        return $this->active;
+    }
+
     public function isActive(): bool
     {
         return $this->active;

--- a/Tests/Functional/Fixtures/NonCacheableProvider.php
+++ b/Tests/Functional/Fixtures/NonCacheableProvider.php
@@ -41,6 +41,11 @@ final class NonCacheableProvider implements MonitoringProvider
         return 'Test non-cacheable provider for functional tests';
     }
 
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
     public function isActive(): bool
     {
         return true;

--- a/Tests/Functional/Fixtures/ShortCacheProvider.php
+++ b/Tests/Functional/Fixtures/ShortCacheProvider.php
@@ -44,6 +44,11 @@ final class ShortCacheProvider implements CacheableMonitoringProvider
         return 'Test provider with short cache lifetime';
     }
 
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
     public function isActive(): bool
     {
         return true;

--- a/Tests/Unit/Command/MonitoringCommandTest.php
+++ b/Tests/Unit/Command/MonitoringCommandTest.php
@@ -94,12 +94,59 @@ final class MonitoringCommandTest extends Framework\TestCase
     }
 
     #[Test]
+    public function skipsDisabledProvidersEvenWhenTheyClaimToBeActive(): void
+    {
+        $active = $this->createProvider('EnabledActiveProvider', isActive: true, isHealthy: true);
+
+        // Contradicts itself: disabled by the operator, yet isActive() === true.
+        // isEnabled() is the kill-switch, so it must not be executed.
+        $disabledButActive = new class () implements MonitoringProvider {
+            public function getName(): string
+            {
+                return 'DisabledButActiveProvider';
+            }
+
+            public function isEnabled(): bool
+            {
+                return false;
+            }
+
+            public function getDescription(): string
+            {
+                return '';
+            }
+
+            public function isActive(): bool
+            {
+                return true;
+            }
+
+            public function execute(): MonitoringResult
+            {
+                return new MonitoringResult('DisabledButActiveProvider', false);
+            }
+        };
+
+        $tester = new CommandTester(new MonitoringCommand([$active, $disabledButActive], $this->createExecutionHandler()));
+        $exitCode = $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('EnabledActiveProvider', $display);
+        self::assertStringNotContainsString('DisabledButActiveProvider', $display);
+    }
+
+    #[Test]
     public function rendersAllActiveProvidersWithStatusMarkers(): void
     {
         $healthy = new class () implements MonitoringProvider {
             public function getName(): string
             {
                 return 'AlphaProvider';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
             }
             public function getDescription(): string
             {
@@ -119,6 +166,10 @@ final class MonitoringCommandTest extends Framework\TestCase
             public function getName(): string
             {
                 return 'BetaProvider';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
             }
             public function getDescription(): string
             {
@@ -196,6 +247,11 @@ final class MonitoringCommandTest extends Framework\TestCase
             public function getDescription(): string
             {
                 return '';
+            }
+
+            public function isEnabled(): bool
+            {
+                return $this->active;
             }
 
             public function isActive(): bool

--- a/Tests/Unit/Command/ReportCommandTest.php
+++ b/Tests/Unit/Command/ReportCommandTest.php
@@ -202,6 +202,11 @@ final class ReportCommandTest extends TestCase
                 return '';
             }
 
+            public function isEnabled(): bool
+            {
+                return true;
+            }
+
             public function isActive(): bool
             {
                 return true;

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -325,6 +325,10 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             {
                 return 'counted';
             }
+            public function isEnabled(): bool
+            {
+                return true;
+            }
             public function getDescription(): string
             {
                 return 'Counts how often execute() is called.';
@@ -372,6 +376,10 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             public function getName(): string
             {
                 return 'cacheable';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
             }
             public function getDescription(): string
             {
@@ -523,6 +531,66 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
 
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
+    public function disabledProviderIsExcludedFromHealthOutputEvenIfActive(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        // Contradicts itself: disabled yet active. isEnabled() is the
+        // kill-switch, so it must never be executed or reported.
+        $disabledButActive = new class () implements MonitoringProvider {
+            public function getName(): string
+            {
+                return 'DisabledButActive';
+            }
+
+            public function isEnabled(): bool
+            {
+                return false;
+            }
+
+            public function getDescription(): string
+            {
+                return '';
+            }
+
+            public function isActive(): bool
+            {
+                return true;
+            }
+
+            public function execute(): Result
+            {
+                return new MonitoringResult('DisabledButActive', false);
+            }
+        };
+
+        $middleware = new MonitoringMiddleware(
+            [$disabledButActive, $this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler(),
+        );
+
+        $response = $middleware->process(new ServerRequest(new Uri('https://example.com/monitor/health'), 'GET'), $this->handler);
+
+        // The disabled provider never ran, so only the healthy one counts.
+        self::assertSame(200, $response->getStatusCode());
+
+        $decoded = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        $services = $decoded['services'] ?? null;
+        self::assertIsArray($services);
+        self::assertArrayHasKey('database', $services);
+        self::assertArrayNotHasKey('DisabledButActive', $services);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function responseListsSubResultStatusesPerService(): void
     {
         $this->configuration = $this->createConfigurationFromData([
@@ -534,6 +602,10 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             public function getName(): string
             {
                 return 'Scheduler';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
             }
             public function getDescription(): string
             {
@@ -682,6 +754,10 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
             public function getName(): string
             {
                 return 'database';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
             }
 
             public function getDescription(): string

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,6 +7,7 @@
 # customsubcategory=20=Admin User Authorizer
 # customsubcategory=30=Report Dispatcher
 # customsubcategory=40=Email Reporter
+# customsubcategory=50=Scheduler Provider
 
 api {
     # cat=endpoint/1/10; type=string; label=Endpoint Route
@@ -39,6 +40,16 @@ authorizer {
     }
 }
 
+provider {
+    mteu\Monitoring\Provider\SchedulerMonitoringProvider {
+        # cat=provider/50/10; type=boolean; label=Enable Scheduler Provider:Monitors TYPO3 scheduler tasks. Inactive when the scheduler extension is not installed.
+        enabled=1
+        # cat=provider/50/20; type=int+; label=Heartbeat threshold (seconds):Maximum age of the last scheduler run before the heartbeat is reported unhealthy. Detects a broken cron job. Set to 0 to disable. Defaults to 900 (15 minutes).
+        heartbeatThreshold=900
+        # cat=provider/50/30; type=int+; label=Overdue threshold (seconds):Grace period after a task's scheduled next execution time before it is reported as overdue. Tasks configured for manual execution are excluded automatically. Set to 0 to disable. Defaults to 300 (5 minutes).
+        overdueThreshold=300
+    }
+}
 reportDispatcher {
     # cat=reporter/30/10; type=int+; label=Reminder interval (seconds):Minimum seconds between repeated notifications for an unchanged failure set. Default 86400 (once per day). A changed failure set always notifies immediately.
     reminderInterval=86400


### PR DESCRIPTION
Previously a provider was "on" or "off" through `isActive()` alone, conflating two questions: should it run (operator intent) and can it run right now (runtime readiness). This PR separates them.

> [!IMPORTANT]
This is a breaking change for custom providers: every class implementing `MonitoringProvider` (directly or via `CacheableMonitoringProvider`) must now provide an `isEnabled()` method. Providers shipped with this extension are already updated.

### How to update your provider

Implement `isEnabled()` to express operator intent, and (optionally) narrow `isActive()` to  incude technical preconditions.

Minimal adaptation on your part for an "always on" state: Simply hard return `true` and your provider behaves exactly as before:

```php
public function isEnabled(): bool
{
    return true;
}
```

See `Documentation/migration_v1.md` for background. 