### PR TITLE
[FEATURE] Make the display of services health in JSON output configurable

### DIFF
--- a/Classes/Configuration/MonitoringConfiguration.php
+++ b/Classes/Configuration/MonitoringConfiguration.php
@@ -50,6 +50,8 @@ final readonly class MonitoringConfiguration
         string $endpoint = '/monitor/health',
         #[ExtConfProperty(path: 'api.enforceHttps')]
         public bool $enforceHttps = false,
+        #[ExtConfProperty(path: 'api.includeSubResults')]
+        public bool $includeSubResults = true,
         #[ExtConfProperty(path: 'cache.defaultLifetime')]
         public int $cacheDefaultLifetime = 900,
     ) {

--- a/Classes/Middleware/MonitoringMiddleware.php
+++ b/Classes/Middleware/MonitoringMiddleware.php
@@ -122,11 +122,16 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
             $results = $this->collectResults();
             $isHealthy = $this->isOverallHealthy($results);
 
+            $responseArray = [
+                'isHealthy' => $isHealthy,
+            ];
+
+            if ($this->monitoringConfiguration->includeSubResults) {
+                $responseArray['services'] = $this->summarizeResults($results);
+            }
+
             return $this->jsonResponse(
-                [
-                    'isHealthy' => $isHealthy,
-                    'services' => $this->summarizeResults($results),
-                ],
+                $responseArray,
                 $isHealthy ? 200 : 503,
                 $writeBody,
             );
@@ -238,7 +243,10 @@ final readonly class MonitoringMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param array{code: int, error: string}|array{isHealthy: bool, services: array<non-empty-string, array{status: 'healthy'|'unhealthy', subResults?: array<string, 'healthy'|'unhealthy'>}>} $data
+     * @param array{code: int, error: string}|array{
+     *     isHealthy: bool,
+     *     services?: array<non-empty-string, array{status: 'healthy'|'unhealthy', subResults?: array<string, 'healthy'|'unhealthy'>}>
+     * } $data
      * @throws \JsonException
      */
     private function jsonResponse(array $data, int $statusCode = 200, bool $writeBody = true): ResponseInterface

--- a/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
+++ b/Tests/Unit/Middleware/MonitoringMiddlewareTest.php
@@ -660,6 +660,97 @@ final class MonitoringMiddlewareTest extends Framework\TestCase
 
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
+    public function responseOmitsServicesBlockWhenIncludeSubResultsIsDisabled(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health', 'includeSubResults' => '0'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        // An unhealthy provider with sub-results: even though the per-service
+        // breakdown is suppressed, the overall verdict (and the HTTP status
+        // derived from it) must still reflect the providers' health.
+        $provider = new class () implements MonitoringProvider {
+            public function getName(): string
+            {
+                return 'Scheduler';
+            }
+            public function isEnabled(): bool
+            {
+                return true;
+            }
+            public function getDescription(): string
+            {
+                return 'Provider with sub-results.';
+            }
+            public function isActive(): bool
+            {
+                return true;
+            }
+            public function execute(): Result
+            {
+                return new MonitoringResult('Scheduler', false, null, [
+                    new MonitoringResult('Scheduler Execution', true),
+                    new MonitoringResult('Failed Tasks', false),
+                ]);
+            }
+        };
+
+        $middleware = new MonitoringMiddleware(
+            [$provider, $this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler(),
+        );
+
+        $response = $middleware->process(new ServerRequest(new Uri('https://example.com/monitor/health'), 'GET'), $this->handler);
+
+        // Health still computed from the providers, only the breakdown is gone.
+        self::assertSame(503, $response->getStatusCode());
+
+        $decoded = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['isHealthy' => false], $decoded);
+        self::assertArrayNotHasKey('services', $decoded, 'services must be omitted when includeSubResults is disabled');
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function responseIncludesServicesBlockWhenIncludeSubResultsIsExplicitlyEnabled(): void
+    {
+        $this->configuration = $this->createConfigurationFromData([
+            'api' => ['endpoint' => '/monitor/health', 'includeSubResults' => '1'],
+            'authorizer' => ['mteu\\Monitoring\\Authorization\\TokenAuthorizer' => ['enabled' => '1', 'secret' => 'test-secret', 'priority' => '10', 'authHeaderName' => 'X-Auth']],
+        ]);
+
+        $middleware = new MonitoringMiddleware(
+            [$this->createHealthyProvider()],
+            [$this->createAuthorizedAuthorizer()],
+            $this->configuration,
+            $this->responseFactory,
+            $this->logger,
+            $this->createExecutionHandler(),
+        );
+
+        $response = $middleware->process(new ServerRequest(new Uri('https://example.com/monitor/health'), 'GET'), $this->handler);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $decoded = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(
+            [
+                'isHealthy' => true,
+                'services' => [
+                    'database' => ['status' => 'healthy'],
+                ],
+            ],
+            $decoded,
+        );
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function headRequestReturnsSameStatusAndHeadersWithEmptyBody(): void
     {
         $this->configuration = $this->createConfigurationFromData([

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -14,6 +14,8 @@ api {
     endpoint=/monitor/health
     # cat=endpoint/1/20; type=boolean; label=Enforce HTTPS:Reject monitoring requests that are not HTTPS. TLS is best terminated at the web server / ingress; only enable this once $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP'] / 'reverseProxySSL' (trusted proxies) are configured correctly, otherwise legitimate requests behind a proxy will be rejected.
     enforceHttps=0
+    # cat=endpoint/1/30; type=boolean; label=Include sub results:Include the result of sub components in the JSON output of the endpoint
+    includeSubResults=1
 }
 
 cache {


### PR DESCRIPTION
Makes the display of each service's health in JSON output configurable by extension configuration. Active services will be shown by default:

```php
# system/settings.php

'EXTENSIONS' => [
    // ..
    'monitoring' => [
        'api' => [
            'endpoint' => '/monitor/health',
            'enforceHttps' => '0',
            'includeServicesHealth' => '1',
        ],
       // ..
    ],
    // ..
],
```