### PR TITLE
[TASK] Fail `monitoring:report` if no active reporter has been dispatched

### DIFF
--- a/Classes/Command/ReportCommand.php
+++ b/Classes/Command/ReportCommand.php
@@ -52,9 +52,22 @@ final class ReportCommand extends Command
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $decision = $this->dispatcher->dispatch();
+        $result = $this->dispatcher->dispatch();
 
-        $output->writeln(match ($decision) {
+        // A notification was due but no active reporter delivered it (e.g. the
+        // EmailReporter has no recipient configured).
+        if ($result->isUndelivered()) {
+            $output->writeln(sprintf(
+                '<error>No report dispatched: a %s notification was due but no active reporter '
+                . 'delivered it. Enable and configure at least one reporter '
+                . '(e.g. set an email recipient for the EmailReporter).</error>',
+                strtolower($result->decision->name),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(match ($result->decision) {
             NotificationDecision::None => 'No notification dispatched.',
             NotificationDecision::Unhealthy => 'Dispatched: unhealthy status.',
             NotificationDecision::Reminder => 'Dispatched: reminder for ongoing unhealthy status.',

--- a/Classes/Reporter/DispatchResult.php
+++ b/Classes/Reporter/DispatchResult.php
@@ -20,14 +20,6 @@ namespace mteu\Monitoring\Reporter;
 /**
  * DispatchResult.
  *
- * Outcome of a single {@see ReportDispatcher::dispatch()} run: the dedup state
- * machine's {@see NotificationDecision} plus whether at least one active
- * reporter actually delivered the report. The two can diverge — a notification
- * may be due (`$decision->shouldDispatch()` is true) while no reporter delivers
- * it because none are active (e.g. the EmailReporter has no recipient
- * configured). Callers use {@see self::isUndelivered()} to surface that
- * misconfiguration instead of silently claiming the report was dispatched.
- *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
  */

--- a/Classes/Reporter/DispatchResult.php
+++ b/Classes/Reporter/DispatchResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "monitoring".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace mteu\Monitoring\Reporter;
+
+/**
+ * DispatchResult.
+ *
+ * Outcome of a single {@see ReportDispatcher::dispatch()} run: the dedup state
+ * machine's {@see NotificationDecision} plus whether at least one active
+ * reporter actually delivered the report. The two can diverge — a notification
+ * may be due (`$decision->shouldDispatch()` is true) while no reporter delivers
+ * it because none are active (e.g. the EmailReporter has no recipient
+ * configured). Callers use {@see self::isUndelivered()} to surface that
+ * misconfiguration instead of silently claiming the report was dispatched.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class DispatchResult
+{
+    public function __construct(
+        public NotificationDecision $decision,
+        public bool $delivered,
+    ) {}
+
+    /**
+     * True when a notification was due but no active reporter delivered it.
+     */
+    public function isUndelivered(): bool
+    {
+        return $this->decision->shouldDispatch() && !$this->delivered;
+    }
+}

--- a/Classes/Reporter/ReportDispatcher.php
+++ b/Classes/Reporter/ReportDispatcher.php
@@ -55,7 +55,7 @@ final readonly class ReportDispatcher
         private LoggerInterface $logger,
     ) {}
 
-    public function dispatch(): NotificationDecision
+    public function dispatch(): DispatchResult
     {
         $results = $this->collectResults();
 
@@ -92,7 +92,7 @@ final readonly class ReportDispatcher
 
         $this->persist($healthyNow, $fingerprint, $decision, $anySent, $state, $now);
 
-        return $decision;
+        return new DispatchResult($decision, $anySent);
     }
 
     private function decide(

--- a/Documentation/command-line.md
+++ b/Documentation/command-line.md
@@ -80,9 +80,27 @@ Dispatched: reminder for ongoing unhealthy status.
 Dispatched: recovery notice.
 ```
 
-The command always exits with `0` (`Command::SUCCESS`); whether a notification
-was actually sent depends on the dispatch decision and each reporter's
-threshold.
+#### Return Codes
+
+| Exit Code | Constant           | Meaning                                                             |
+|-----------|--------------------|--------------------------------------------------------------------|
+| 0         | `Command::SUCCESS` | The dispatch decision was handled (nothing due, or delivered)      |
+| 1         | `Command::FAILURE` | A notification was due but no active reporter delivered it         |
+
+A notification can be *due* (the status is unhealthy, a reminder is overdue, or
+a recovery happened) yet remain *undelivered* when no reporter is active — for
+example when the `EmailReporter` has no recipient configured. In that case the
+misconfiguration is reported and the command exits non-zero, e.g.:
+
+```bash
+No report dispatched: An unhealthy notification was due but no active reporter
+delivered it. Enable and configure at least one reporter (e.g. set an email
+recipient for the EmailReporter).
+```
+
+> [!NOTE]
+> The backend Scheduler task (`MonitoringReportTask`) triggers the same dispatch but always reports success to the
+> scheduler. The non-zero exit code is specific to the interactive CLI command.
 
 ## Usage Examples
 

--- a/Tests/Functional/Reporter/ReportDispatcherTest.php
+++ b/Tests/Functional/Reporter/ReportDispatcherTest.php
@@ -24,6 +24,7 @@ use mteu\Monitoring\Configuration\MonitoringConfiguration;
 use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
 use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use mteu\Monitoring\Handler\MonitoringExecutionHandler;
+use mteu\Monitoring\Reporter\DispatchResult;
 use mteu\Monitoring\Reporter\NotificationDecision;
 use mteu\Monitoring\Reporter\ReportDispatcher;
 use mteu\Monitoring\Reporter\Reporter;
@@ -172,11 +173,26 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
         $inactive = new RecordingReporter(ReportThreshold::Always, active: false);
         $provider = new ConfigurableProvider('alpha', healthy: false);
 
-        self::assertSame(
-            NotificationDecision::Unhealthy,
-            $this->dispatch([$provider], [$inactive], 1_000),
-        );
+        $result = $this->dispatchResult([$provider], [$inactive], 1_000);
+
+        self::assertSame(NotificationDecision::Unhealthy, $result->decision);
+        // The decision was to dispatch, but no active reporter delivered it.
+        self::assertFalse($result->delivered);
+        self::assertTrue($result->isUndelivered());
         self::assertSame(0, $inactive->receivedCount());
+    }
+
+    #[Test]
+    public function deliveredFlagIsSetWhenAnActiveReporterDelivers(): void
+    {
+        $reporter = new RecordingReporter(ReportThreshold::Always);
+        $provider = new ConfigurableProvider('alpha', healthy: false);
+
+        $result = $this->dispatchResult([$provider], [$reporter], 1_000);
+
+        self::assertSame(NotificationDecision::Unhealthy, $result->decision);
+        self::assertTrue($result->delivered);
+        self::assertFalse($result->isUndelivered());
     }
 
     #[Test]
@@ -236,6 +252,29 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
         bool $notifyOnRecovery = true,
         bool $failOpenOnMissingState = true,
     ): NotificationDecision {
+        return $this->dispatchResult(
+            $providers,
+            $reporters,
+            $timestamp,
+            $notifyOnRecovery,
+            $failOpenOnMissingState,
+        )->decision;
+    }
+
+    /**
+     * Like {@see self::dispatch()} but exposes the full {@see DispatchResult}
+     * so tests can assert on the delivered flag, not just the decision.
+     *
+     * @param list<ConfigurableProvider> $providers
+     * @param list<Reporter> $reporters
+     */
+    private function dispatchResult(
+        array $providers,
+        array $reporters,
+        int $timestamp,
+        bool $notifyOnRecovery = true,
+        bool $failOpenOnMissingState = true,
+    ): DispatchResult {
         $context = new Context();
         $context->setAspect('date', new DateTimeAspect((new \DateTimeImmutable())->setTimestamp($timestamp)));
 

--- a/Tests/Unit/Command/ReportCommandTest.php
+++ b/Tests/Unit/Command/ReportCommandTest.php
@@ -27,7 +27,10 @@ use mteu\Monitoring\Configuration\Reporter\EmailReporterConfiguration;
 use mteu\Monitoring\Configuration\Reporter\ReportDispatcherConfiguration;
 use mteu\Monitoring\Handler\MonitoringExecutionHandler;
 use mteu\Monitoring\Provider\MonitoringProvider;
+use mteu\Monitoring\Reporter\ReportContext;
 use mteu\Monitoring\Reporter\ReportDispatcher;
+use mteu\Monitoring\Reporter\Reporter;
+use mteu\Monitoring\Reporter\ReportThreshold;
 use mteu\Monitoring\Result\MonitoringResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -68,7 +71,7 @@ final class ReportCommandTest extends TestCase
     #[Test]
     public function commandIsRegisteredWithExpectedNameAndDescription(): void
     {
-        $command = $this->createCommand([], 1_000);
+        $command = $this->createCommand([], 1_000, []);
 
         self::assertSame('monitoring:report', $command->getName());
         self::assertSame(
@@ -80,7 +83,9 @@ final class ReportCommandTest extends TestCase
     #[Test]
     public function reportsNoNotificationWhenEverythingIsHealthy(): void
     {
-        $tester = new CommandTester($this->createCommand([$this->provider('alpha', healthy: true)], 1_000));
+        $tester = new CommandTester(
+            $this->createCommand([$this->provider('alpha', healthy: true)], 1_000, [$this->reporter()]),
+        );
 
         $exitCode = $tester->execute([]);
 
@@ -91,12 +96,29 @@ final class ReportCommandTest extends TestCase
     #[Test]
     public function reportsUnhealthyStatusOnFirstFailure(): void
     {
-        $tester = new CommandTester($this->createCommand([$this->provider('alpha', healthy: false)], 1_000));
+        $tester = new CommandTester(
+            $this->createCommand([$this->provider('alpha', healthy: false)], 1_000, [$this->reporter()]),
+        );
 
         $exitCode = $tester->execute([]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertStringContainsString('Dispatched: unhealthy status.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function reportsFailureWhenDispatchDecidedButNoReporterDelivers(): void
+    {
+        $tester = new CommandTester(
+            $this->createCommand([$this->provider('alpha', healthy: false)], 1_000, [$this->reporter(active: false)]),
+        );
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('No report dispatched', $tester->getDisplay());
+        self::assertStringContainsString('no active reporter', $tester->getDisplay());
+        self::assertStringNotContainsString('Dispatched: unhealthy status.', $tester->getDisplay());
     }
 
     #[Test]
@@ -128,20 +150,21 @@ final class ReportCommandTest extends TestCase
      */
     private function createTester(array $providers, int $timestamp): CommandTester
     {
-        return new CommandTester($this->createCommand($providers, $timestamp));
+        return new CommandTester($this->createCommand($providers, $timestamp, [$this->reporter()]));
     }
 
     /**
      * @param list<MonitoringProvider> $providers
+     * @param list<Reporter> $reporters
      */
-    private function createCommand(array $providers, int $timestamp): ReportCommand
+    private function createCommand(array $providers, int $timestamp, array $reporters): ReportCommand
     {
         $context = new Context();
         $context->setAspect('date', new DateTimeAspect((new \DateTimeImmutable())->setTimestamp($timestamp)));
 
         $dispatcher = new ReportDispatcher(
             $providers,
-            [], // reporters are irrelevant to the command's decision-to-output mapping
+            $reporters,
             new MonitoringExecutionHandler(new MonitoringCacheManager(new CacheManager())),
             new NotificationStateCacheManager($this->inMemoryCacheManager()),
             new MonitoringConfiguration(
@@ -180,6 +203,41 @@ final class ReportCommandTest extends TestCase
         $cacheManager->method('getCache')->willReturn($frontend);
 
         return $cacheManager;
+    }
+
+    // A reporter that accepts every decision and, when active, delivers successfully.
+    private function reporter(bool $active = true): Reporter
+    {
+        return new readonly class ($active) implements Reporter {
+            public function __construct(
+                private bool $active,
+            ) {}
+
+            public function isActive(): bool
+            {
+                return $this->active;
+            }
+
+            public function getThreshold(): ReportThreshold
+            {
+                return ReportThreshold::Always;
+            }
+
+            public function report(ReportContext $context): bool
+            {
+                return true;
+            }
+
+            public function getName(): string
+            {
+                return 'Fake Reporter';
+            }
+
+            public static function getPriority(): int
+            {
+                return 0;
+            }
+        };
     }
 
     private function provider(string $name, bool $healthy): MonitoringProvider


### PR DESCRIPTION
Adds a `DispatchResult` value object carrying the `NotificationDecision` **and** whether an active reporter delivered, with an `isUndelivered()` helper (`decision->shouldDispatch() && !delivered`). `ReportCommand` detects the "notification due but undelivered" case, prints an explanatory message, and exits with `Command::FAILURE` (`1`) instead of falsely reporting success.