### PR TITLE
[TASK] Localize scheduler heartbeat age via core DateFormatter

### DIFF
--- a/Classes/Provider/Scheduler/SchedulerProvider.php
+++ b/Classes/Provider/Scheduler/SchedulerProvider.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\Router;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Localization\DateFormatter;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -305,28 +306,17 @@ final readonly class SchedulerProvider implements MonitoringProvider
         return $this->languageServiceFactory->createFromUserPreferences(null);
     }
 
-    /**
-     * Relative-age wording is still assembled in English here; it is slated to
-     * move to a Fluid view helper (see the test's @todo), at which point it
-     * will localize alongside the rest of the module chrome.
-     */
     private function formatAge(int $seconds): string
     {
-        $minutes = (int)($seconds / 60);
-        $hours = (int)($minutes / 60);
-        $days = (int)($hours / 24);
+        $now = $this->clock->now();
+        $past = $now->sub(new \DateInterval('PT' . max(0, $seconds) . 'S'));
 
-        $remMinutes = $minutes % 60;
-        $remHours = $hours % 24;
-
-        return match (true) {
-            $days > 0 => $days . ' ' . ($days === 1 ? 'day' : 'days')
-                . ($remHours > 0 ? ' and ' . $remHours . ' ' . ($remHours === 1 ? 'hour' : 'hours') : ''),
-            $hours > 0 => $hours . ' ' . ($hours === 1 ? 'hour' : 'hours')
-                . ($remMinutes > 0 ? ' and ' . $remMinutes . ' ' . ($remMinutes === 1 ? 'minute' : 'minutes') : ''),
-            $minutes > 0 => $minutes . ' ' . ($minutes === 1 ? 'minute' : 'minutes'),
-            default => $seconds . ' ' . ($seconds === 1 ? 'second' : 'seconds'),
-        };
+        return DateFormatter::formatDateInterval(
+            $past->diff($now),
+            $this->getLanguageService()->sL(
+                'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.minutesHoursDaysYears',
+            ),
+        );
     }
 
     public function renderEditLink(int $uid, string $label): ?string

--- a/Tests/Unit/Provider/SchedulerProviderTest.php
+++ b/Tests/Unit/Provider/SchedulerProviderTest.php
@@ -105,16 +105,13 @@ final class SchedulerProviderTest extends Framework\TestCase
     }
 
     #[Test]
-    // @todo: remove date calcuation. replace with fluid viewhelper
-    public function staleHeartbeatReasonStatesTheRealAgeNotASingleSecond(): void
+    public function staleHeartbeatReasonStatesLastRunFormatted(): void
     {
-        // 10 000 s = 2 h 46 m 40 s; formatAge drops seconds when minutes > 0 → "2 hours and 46 minutes".
+        // 10 000 s = 2 h 46 m 40 s
         $result = $this->createProvider(lastRunEnd: self::NOW - 10_000)->execute();
 
         $reason = (string)$result->getSubResults()[0]->getReason();
-
-        self::assertStringContainsString('2 hours and 46 minutes ago', $reason);
-        self::assertStringNotContainsString('1 seconds ago', $reason);
+        self::assertStringContainsString('2 hrs ago', $reason);
     }
 
     #[Test]


### PR DESCRIPTION
Replace the hardcoded English relative-age wording in `SchedulerProvider::formatAge ` with TYPO3 core's own mechanism.