### PR TITLE
[FEATURE] Add `notifyFrom` option to alert on degraded health state

### DIFF
--- a/Classes/Configuration/Provider/SchedulerProviderConfiguration.php
+++ b/Classes/Configuration/Provider/SchedulerProviderConfiguration.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Configuration\Provider;
 
+use mteu\Monitoring\Result\Status;
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
@@ -32,22 +33,34 @@ final readonly class SchedulerProviderConfiguration implements ProviderConfigura
     public function __construct(
         #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SchedulerProvider.enabled')]
         private bool $enabled = true,
+
         /**
-         * Maximum age (in seconds) of the last scheduler run before the
-         * heartbeat is considered unhealthy. This detects a broken cron job
-         * that no longer invokes the scheduler at all. Set to 0 to disable
-         * the heartbeat check.
+         * Maximum age (in seconds) of the last scheduler run before the heartbeat is considered
+         * unhealthy. Set to 0 to disable the heartbeat check.
          */
         #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SchedulerProvider.heartbeatThreshold')]
         public int $heartbeatThreshold = 900,
+
         /**
-         * Grace period (in seconds) after a task's scheduled next execution
-         * time before it is reported as overdue. Only tasks with an explicit
-         * next-execution time are considered; tasks configured for manual
-         * execution are excluded automatically. Set to 0 to disable.
+         * Grace period (in seconds) after a task's scheduled next execution time before it is
+         * reported as overdue. Only tasks with an explicit next-execution time are considered;
+         * tasks configured for manual execution are excluded automatically. Set to 0 to disable.
          */
         #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SchedulerProvider.overdueThreshold')]
         public int $overdueThreshold = 300,
+
+        /**
+         * Severity reported when a task is overdue. Failed tasks are always unhealthy.
+         */
+        #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SchedulerProvider.overdueSeverity')]
+        public Status $overdueSeverity = Status::Unhealthy,
+
+        /**
+         * Severity reported when the scheduler heartbeat is stale (cron has not invoked the scheduler
+         * within {@see self::$heartbeatThreshold}).A heartbeat that has never run at all is always unhealthy.
+         */
+        #[ExtConfProperty(path: 'provider.mteu\\Monitoring\\Provider\\SchedulerProvider.heartbeatStaleSeverity')]
+        public Status $heartbeatStaleSeverity = Status::Unhealthy,
     ) {}
 
     public function isEnabled(): bool

--- a/Classes/Configuration/Reporter/ReportDispatcherConfiguration.php
+++ b/Classes/Configuration/Reporter/ReportDispatcherConfiguration.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace mteu\Monitoring\Configuration\Reporter;
 
+use mteu\Monitoring\Result\Status;
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
@@ -38,5 +39,12 @@ final readonly class ReportDispatcherConfiguration
         public bool $notifyOnRecovery = true,
         #[ExtConfProperty(path: 'reportDispatcher.failOpenOnMissingState')]
         public bool $failOpenOnMissingState = true,
+
+        /**
+         * Severity floor at which a provider result enters the failure set and is allowed to notify.
+         * Defaults to {@see Status::Unhealthy} so a `degraded` result stays a silent HTTP 200.
+         */
+        #[ExtConfProperty(path: 'reportDispatcher.notifyFrom')]
+        public Status $notifyFrom = Status::Unhealthy,
     ) {}
 }

--- a/Classes/Provider/Scheduler/SchedulerProvider.php
+++ b/Classes/Provider/Scheduler/SchedulerProvider.php
@@ -132,7 +132,7 @@ final readonly class SchedulerProvider implements MonitoringProvider
         if ($age > $this->configuration->heartbeatThreshold) {
             return new MonitoringResult(
                 'Scheduler',
-                Status::Unhealthy,
+                $this->configuration->heartbeatStaleSeverity,
                 $this->translate(
                     'provider.scheduler.heartbeat.stale',
                     $this->formatAge($age),
@@ -192,7 +192,7 @@ final readonly class SchedulerProvider implements MonitoringProvider
 
         return new MonitoringResult(
             'Overdue Tasks',
-            Status::Unhealthy,
+            $this->configuration->overdueSeverity,
             $this->translate(
                 $count > 1 ? 'provider.scheduler.overdue.plural' : 'provider.scheduler.overdue.singular',
                 $count,

--- a/Classes/Reporter/EmailReporter.php
+++ b/Classes/Reporter/EmailReporter.php
@@ -189,10 +189,12 @@ final readonly class EmailReporter implements Reporter
         };
         $lines[] = '';
 
-        foreach ($context->results as $result) {
-            $status = $result->isHealthy()
-                ? $this->translate($languageService, 'reporter.email.status.ok')
-                : $this->translate($languageService, 'reporter.email.status.failed');
+        foreach ($context->results as $name => $result) {
+            // Base the per-line marker on the failure set o a degraded provider that crossed the notify floor is
+            // shown as FAILED, not OK, when the severity floor is set to degraded.
+            $status = \in_array($name, $context->unhealthyProviderNames, true)
+                ? $this->translate($languageService, 'reporter.email.status.failed')
+                : $this->translate($languageService, 'reporter.email.status.ok');
             $reason = $result->getReason();
             $lines[] = $this->translate(
                 $languageService,

--- a/Classes/Reporter/ReportDispatcher.php
+++ b/Classes/Reporter/ReportDispatcher.php
@@ -30,9 +30,8 @@ use TYPO3\CMS\Core\Context\Context;
 /**
  * ReportDispatcher.
  *
- * Shared "brain" used by both the CLI command and the (optional) scheduler
- * task: evaluates active providers, runs the dedup state machine, and fans
- * out to active reporters according to each reporter's threshold.
+ * Shared "brain" used by both the CLI command and the (optional) scheduler task.
+ * Evaluates active providers and dispatches active reporters according to each reporter's threshold.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
@@ -59,9 +58,11 @@ final readonly class ReportDispatcher
     {
         $results = $this->collectResults();
 
+        $dispatcherConfiguration = $this->configuration->reporterDispatcherConfiguration;
+
         $unhealthyNames = [];
         foreach ($results as $name => $result) {
-            if (!$result->isHealthy()) {
+            if ($result->getStatus()->isAtLeast($dispatcherConfiguration->notifyFrom)) {
                 $unhealthyNames[] = $name;
             }
         }
@@ -73,8 +74,6 @@ final readonly class ReportDispatcher
         $now = $this->now();
 
         $state = $this->stateCacheManager->load();
-
-        $dispatcherConfiguration = $this->configuration->reporterDispatcherConfiguration;
 
         $decision = $this->decide(
             $healthyNow,
@@ -144,8 +143,7 @@ final readonly class ReportDispatcher
             return;
         }
 
-        // Only advance the reminder clock when a notification was actually
-        // delivered, so a failed send is retried on the next run.
+        // Only advance the reminder clock when a notification was actually delivered, so a failed send is retried on the next run.
         $lastNotifiedAt = $anySent ? $now : $previousLastNotified;
         $this->stateCacheManager->save(new NotificationState($fingerprint, $lastNotifiedAt, false));
     }
@@ -195,9 +193,6 @@ final readonly class ReportDispatcher
     }
 
     /**
-     * Keyed by the provider's name (matching the middleware's status map) so
-     * two instances of the same provider class do not collide.
-     *
      * @return array<non-empty-string, Result>
      */
     private function collectResults(): array

--- a/Documentation/Providers/Scheduler.md
+++ b/Documentation/Providers/Scheduler.md
@@ -37,6 +37,8 @@ return [
                     'enabled' => true,
                     'heartbeatThreshold' => 900,
                     'overdueThreshold' => 300,
+                    'overdueSeverity' => 'unhealthy',
+                    'heartbeatStaleSeverity' => 'unhealthy',
                 ],
             ],
         ],
@@ -49,10 +51,20 @@ return [
 | `enabled`            | `true`  | Enables the provider. When `false` the provider reports as inactive.                                |
 | `heartbeatThreshold` | `900`   | Max age (seconds) of the last scheduler run before the heartbeat is unhealthy. `0` disables it.     |
 | `overdueThreshold`   | `300`   | Grace period (seconds) added to a task's next-execution time before it is overdue. `0` disables it. |
+| `overdueSeverity`        | `unhealthy` | Status reported for an overdue task: `unhealthy` (an outage — HTTP 503, may notify) or `degraded` (visible on the endpoint at HTTP 200, no notification). |
+| `heartbeatStaleSeverity` | `unhealthy` | Status reported when the heartbeat is stale: `unhealthy` or `degraded`. A heartbeat that never ran at all is always `unhealthy`. |
 
 Tune the thresholds to your cron frequency: `heartbeatThreshold` should comfortably
 exceed how often cron runs the scheduler, and `overdueThreshold` should absorb the
 expected runtime of your longest scheduled task.
+
+The severity knobs let you classify, per condition, what counts as `degraded`
+versus `unhealthy` — for example "an overdue task is FYI (`degraded`), a failed
+task is an outage (`unhealthy`)". Failed tasks are always `unhealthy` and have no
+knob. A `degraded` sub-result keeps the Scheduler's aggregate status at
+`degraded` (HTTP 200) and, by default, does **not** notify; pair it with
+`reportDispatcher.notifyFrom = degraded` (see [Reporters](../Reporters.md)) if
+you do want degradation to page.
 
 ## Example output
 

--- a/Documentation/Reporters.md
+++ b/Documentation/Reporters.md
@@ -26,7 +26,30 @@ cannot make the dispatcher forget it already alerted. A failed delivery does
 not advance the reminder clock, so it is retried on the next run.
 
 See [Configuration](Configuration.md) for the `reportDispatcher` settings
-(`reminderInterval`, `notifyOnRecovery`, `failOpenOnMissingState`).
+(`reminderInterval`, `notifyOnRecovery`, `failOpenOnMissingState`, `notifyFrom`).
+
+## Severity floor (`notifyFrom`)
+
+A provider can report `healthy`, `degraded` or `unhealthy`. The dispatcher
+builds its failure set from every result whose status is **at least** the
+configured `reportDispatcher.notifyFrom` floor:
+
+| `notifyFrom` | Pages on            | `degraded` behaviour                          |
+|--------------|---------------------|-----------------------------------------------|
+| `unhealthy`  | `unhealthy` only    | silent — stays HTTP 200, never notifies (default) |
+| `degraded`   | `degraded` + `unhealthy` | enters the failure set and notifies      |
+
+The floor is **global**: it is a single severity gate in front of the one
+shared dedup/reminder/recovery state machine, not a per-reporter setting.
+Lowering it to `degraded` makes degradation page through exactly the same
+fingerprint/reminder/recovery machinery as an outage. Recovery (`Recovered`)
+then fires when the status drops back **below the floor**, which is not
+necessarily fully healthy — the recovery copy is worded accordingly.
+
+This is distinct from the per-reporter **threshold** below: `notifyFrom` decides
+*what counts as a failure* (a severity gate), while a reporter's threshold
+decides *which decisions* (`Unhealthy` / `Reminder` / `Recovered`) it wants
+once that failure has been determined.
 
 ## Thresholds
 
@@ -37,6 +60,10 @@ Each reporter declares which decisions it wants via `ReportThreshold`:
 | `always`       | `Unhealthy`, `Reminder`, `Recovered` |
 | `unhealthy`    | `Unhealthy`, `Reminder`           |
 | `state-change` | `Unhealthy`, `Recovered`          |
+
+> `ReportThreshold::Unhealthy` keeps its name for backward compatibility; read
+> it as "the failure decision", where *failure* means a result met the
+> `notifyFrom` floor — not literally the `unhealthy` status.
 
 ## Custom Reporter
 

--- a/Resources/Private/Language/de.locallang.be.xlf
+++ b/Resources/Private/Language/de.locallang.be.xlf
@@ -464,8 +464,8 @@
                 <target>Eine oder mehrere Scheduler-Prüfungen sind fehlgeschlagen. Details siehe Teilergebnisse.</target>
             </trans-unit>
             <trans-unit id="reporter.email.subject.recovered">
-                <source>All monitored services recovered</source>
-                <target>Alle überwachten Dienste wiederhergestellt</target>
+                <source>Monitored services recovered</source>
+                <target>Überwachte Dienste wiederhergestellt</target>
             </trans-unit>
             <trans-unit id="reporter.email.subject.reminder">
                 <source>Still unhealthy: %s</source>
@@ -476,8 +476,8 @@
                 <target>Fehlerhaft: %s</target>
             </trans-unit>
             <trans-unit id="reporter.email.body.recovered">
-                <source>All monitored services are healthy again.</source>
-                <target>Alle überwachten Dienste sind wieder fehlerfrei.</target>
+                <source>Monitored services have recovered and are no longer above the alerting threshold.</source>
+                <target>Die überwachten Dienste haben sich erholt und liegen nicht mehr über der Benachrichtigungsschwelle.</target>
             </trans-unit>
             <trans-unit id="reporter.email.body.reminder">
                 <source>The following services are still reporting an unhealthy state:</source>

--- a/Resources/Private/Language/locallang.be.xlf
+++ b/Resources/Private/Language/locallang.be.xlf
@@ -352,7 +352,7 @@
                 <source>One or more scheduler health checks failed. See sub-results for details.</source>
             </trans-unit>
             <trans-unit id="reporter.email.subject.recovered">
-                <source>All monitored services recovered</source>
+                <source>Monitored services recovered</source>
             </trans-unit>
             <trans-unit id="reporter.email.subject.reminder">
                 <source>Still unhealthy: %s</source>
@@ -361,7 +361,7 @@
                 <source>Unhealthy: %s</source>
             </trans-unit>
             <trans-unit id="reporter.email.body.recovered">
-                <source>All monitored services are healthy again.</source>
+                <source>Monitored services have recovered and are no longer above the alerting threshold.</source>
             </trans-unit>
             <trans-unit id="reporter.email.body.reminder">
                 <source>The following services are still reporting an unhealthy state:</source>

--- a/Tests/Functional/Fixtures/ConfigurableProvider.php
+++ b/Tests/Functional/Fixtures/ConfigurableProvider.php
@@ -32,6 +32,8 @@ use mteu\Monitoring\Result\Status;
  */
 final class ConfigurableProvider implements MonitoringProvider
 {
+    private ?Status $status = null;
+
     public function __construct(
         /** @var non-empty-string $identifier */
         private readonly string $identifier,
@@ -42,6 +44,16 @@ final class ConfigurableProvider implements MonitoringProvider
     public function setHealthy(bool $healthy): void
     {
         $this->healthy = $healthy;
+        $this->status = null;
+    }
+
+    /**
+     * Pins an explicit status, overriding the healthy/unhealthy toggle. Lets a
+     * test emit a `degraded` result to exercise the notify-from severity floor.
+     */
+    public function setStatus(Status $status): void
+    {
+        $this->status = $status;
     }
 
     public function getName(): string
@@ -66,6 +78,8 @@ final class ConfigurableProvider implements MonitoringProvider
 
     public function execute(): Result
     {
-        return new MonitoringResult($this->identifier, $this->healthy ? Status::Healthy : Status::Unhealthy);
+        $status = $this->status ?? ($this->healthy ? Status::Healthy : Status::Unhealthy);
+
+        return new MonitoringResult($this->identifier, $status);
     }
 }

--- a/Tests/Functional/Reporter/ReportDispatcherTest.php
+++ b/Tests/Functional/Reporter/ReportDispatcherTest.php
@@ -29,6 +29,7 @@ use mteu\Monitoring\Reporter\NotificationDecision;
 use mteu\Monitoring\Reporter\ReportDispatcher;
 use mteu\Monitoring\Reporter\Reporter;
 use mteu\Monitoring\Reporter\ReportThreshold;
+use mteu\Monitoring\Result\Status;
 use mteu\Monitoring\Tests\Functional\Fixtures\ConfigurableProvider;
 use mteu\Monitoring\Tests\Functional\Fixtures\RecordingReporter;
 use mteu\Monitoring\Tests\Functional\Fixtures\ThrowingReporter;
@@ -238,6 +239,58 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
         self::assertSame(0, $reporter->receivedCount());
     }
 
+    #[Test]
+    public function degradedProviderDoesNotNotifyUnderTheDefaultFloor(): void
+    {
+        $reporter = new RecordingReporter(ReportThreshold::Always);
+        $provider = new ConfigurableProvider('alpha');
+        $provider->setStatus(Status::Degraded);
+
+        // notifyFrom defaults to Unhealthy: a degraded result stays a silent 200.
+        self::assertSame(
+            NotificationDecision::None,
+            $this->dispatch([$provider], [$reporter], 1_000),
+        );
+        self::assertSame(0, $reporter->receivedCount());
+    }
+
+    #[Test]
+    public function degradedProviderNotifiesWhenFloorIsLoweredToDegraded(): void
+    {
+        $reporter = new RecordingReporter(ReportThreshold::Always);
+        $provider = new ConfigurableProvider('alpha');
+        $provider->setStatus(Status::Degraded);
+
+        self::assertSame(
+            NotificationDecision::Unhealthy,
+            $this->dispatch([$provider], [$reporter], 1_000, notifyFrom: Status::Degraded),
+        );
+        self::assertSame(1, $reporter->receivedCount());
+    }
+
+    #[Test]
+    public function recoveryFiresWhenStatusDropsBelowTheFloor(): void
+    {
+        $reporter = new RecordingReporter(ReportThreshold::Always);
+        $provider = new ConfigurableProvider('alpha');
+        $provider->setStatus(Status::Degraded);
+
+        // Degraded crosses the lowered floor and pages.
+        self::assertSame(
+            NotificationDecision::Unhealthy,
+            $this->dispatch([$provider], [$reporter], 1_000, notifyFrom: Status::Degraded),
+        );
+
+        // Dropping to healthy clears the failure set: recovery, even though the
+        // floor is Degraded rather than Unhealthy.
+        $provider->setStatus(Status::Healthy);
+        self::assertSame(
+            NotificationDecision::Recovered,
+            $this->dispatch([$provider], [$reporter], 1_005, notifyFrom: Status::Degraded),
+        );
+        self::assertSame(2, $reporter->receivedCount());
+    }
+
     /**
      * Runs a freshly wired dispatcher at the given wall-clock timestamp so the
      * dedup state machine sees advancing time across runs within one test.
@@ -251,6 +304,7 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
         int $timestamp,
         bool $notifyOnRecovery = true,
         bool $failOpenOnMissingState = true,
+        Status $notifyFrom = Status::Unhealthy,
     ): NotificationDecision {
         return $this->dispatchResult(
             $providers,
@@ -258,6 +312,7 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
             $timestamp,
             $notifyOnRecovery,
             $failOpenOnMissingState,
+            $notifyFrom,
         )->decision;
     }
 
@@ -274,6 +329,7 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
         int $timestamp,
         bool $notifyOnRecovery = true,
         bool $failOpenOnMissingState = true,
+        Status $notifyFrom = Status::Unhealthy,
     ): DispatchResult {
         $context = new Context();
         $context->setAspect('date', new DateTimeAspect((new \DateTimeImmutable())->setTimestamp($timestamp)));
@@ -291,6 +347,7 @@ final class ReportDispatcherTest extends MonitoringFunctionalTestCase
                     reminderInterval: self::REMINDER_INTERVAL,
                     notifyOnRecovery: $notifyOnRecovery,
                     failOpenOnMissingState: $failOpenOnMissingState,
+                    notifyFrom: $notifyFrom,
                 ),
             ),
             $context,

--- a/Tests/Unit/Configuration/Provider/SchedulerProviderConfigurationTest.php
+++ b/Tests/Unit/Configuration/Provider/SchedulerProviderConfigurationTest.php
@@ -53,4 +53,13 @@ final class SchedulerProviderConfigurationTest extends Framework\TestCase
 
         self::assertTrue($subject->isOverdueCheckEnabled());
     }
+
+    #[Test]
+    public function severitiesDefaultToUnhealthyToPreserveExistingBehaviour(): void
+    {
+        $subject = new Src\Configuration\Provider\SchedulerProviderConfiguration();
+
+        self::assertSame(Src\Result\Status::Unhealthy, $subject->overdueSeverity);
+        self::assertSame(Src\Result\Status::Unhealthy, $subject->heartbeatStaleSeverity);
+    }
 }

--- a/Tests/Unit/Provider/SchedulerProviderTest.php
+++ b/Tests/Unit/Provider/SchedulerProviderTest.php
@@ -21,6 +21,7 @@ use mteu\Monitoring\Configuration\Provider\SchedulerProviderConfiguration;
 use mteu\Monitoring\Provider\Scheduler\SchedulerProvider;
 use mteu\Monitoring\Provider\Scheduler\SchedulerTask;
 use mteu\Monitoring\Result\MonitoringResult;
+use mteu\Monitoring\Result\Status;
 use mteu\Monitoring\Tests\Unit\Fixtures\Language\XliffLanguageServiceFactoryTrait;
 use mteu\Monitoring\Tests\Unit\Fixtures\Scheduler\InMemorySchedulerHeartbeat;
 use mteu\Monitoring\Tests\Unit\Fixtures\Scheduler\InMemorySchedulerTaskRepository;
@@ -231,6 +232,67 @@ final class SchedulerProviderTest extends Framework\TestCase
         $overdue = $result->getSubResults()[1];
         self::assertTrue($overdue->isHealthy());
         self::assertStringContainsString('disabled', (string)$overdue->getReason());
+    }
+
+    #[Test]
+    public function overdueTasksAreUnhealthyByDefault(): void
+    {
+        $overdue = $this->createProvider(overdueCount: 2)->execute()->getSubResults()[1];
+
+        self::assertSame(Status::Unhealthy, $overdue->getStatus());
+    }
+
+    #[Test]
+    public function overdueSeverityCanBeDowngradedToDegraded(): void
+    {
+        $result = $this->createProvider(
+            configuration: new SchedulerProviderConfiguration(overdueSeverity: Status::Degraded),
+            overdueCount: 2,
+        )->execute();
+
+        $overdue = $result->getSubResults()[1];
+        self::assertSame(Status::Degraded, $overdue->getStatus());
+
+        // Degraded is not an outage: the aggregated result stays a non-failing 200.
+        self::assertSame(Status::Degraded, $result->getStatus());
+        self::assertTrue($result->isHealthy());
+    }
+
+    #[Test]
+    public function staleHeartbeatSeverityCanBeDowngradedToDegraded(): void
+    {
+        $result = $this->createProvider(
+            configuration: new SchedulerProviderConfiguration(heartbeatStaleSeverity: Status::Degraded),
+            lastRunEnd: self::NOW - 10_000,
+        )->execute();
+
+        $heartbeat = $result->getSubResults()[0];
+        self::assertSame(Status::Degraded, $heartbeat->getStatus());
+        self::assertTrue($result->isHealthy());
+    }
+
+    #[Test]
+    public function failedTasksStayUnhealthyEvenWhenOverdueSeverityIsDegraded(): void
+    {
+        $result = $this->createProvider(
+            configuration: new SchedulerProviderConfiguration(overdueSeverity: Status::Degraded),
+            failedCount: 1,
+        )->execute();
+
+        self::assertSame(Status::Unhealthy, $result->getSubResults()[2]->getStatus());
+        self::assertFalse($result->isHealthy());
+    }
+
+    #[Test]
+    public function heartbeatThatNeverRanStaysUnhealthyEvenWhenStaleSeverityIsDegraded(): void
+    {
+        $result = $this->createProvider(
+            configuration: new SchedulerProviderConfiguration(heartbeatStaleSeverity: Status::Degraded),
+            lastRunEnd: null,
+        )->execute();
+
+        self::assertSame(Status::Unhealthy, $result->getSubResults()[0]->getStatus());
+        self::assertFalse($result->isHealthy());
     }
 
     #[Test]

--- a/Tests/Unit/Reporter/EmailReporterTest.php
+++ b/Tests/Unit/Reporter/EmailReporterTest.php
@@ -231,12 +231,45 @@ final class EmailReporterTest extends TestCase
         $reporter->report($context);
 
         self::assertInstanceOf(Email::class, $message);
-        self::assertSame('[Monitoring] All monitored services recovered', $message->getSubject());
+        self::assertSame('[Monitoring] Monitored services recovered', $message->getSubject());
         self::assertSame(
-            "All monitored services are healthy again.\n"
+            "Monitored services have recovered and are no longer above the alerting threshold.\n"
             . "\n"
             . "[OK] db\n"
             . "[OK] scheduler\n",
+            $message->getTextBody(),
+        );
+    }
+
+    #[Test]
+    public function reportMarksADegradedProviderInTheFailureSetAsFailed(): void
+    {
+        // With notifyFrom=Degraded a degraded provider crosses the floor and is listed in the failure set,
+        // so its line must read FAILED — not OK, which isHealthy() would have produced for a degraded result.
+        $reporter = $this->reporter(
+            enabled: true,
+            recipients: 'ops@example.com',
+            sentMessage: $message,
+        );
+
+        $context = new ReportContext(
+            NotificationDecision::Unhealthy,
+            [
+                'scheduler' => new MonitoringResult('scheduler', Status::Degraded, 'Overdue task'),
+                'cache' => new MonitoringResult('cache', Status::Healthy),
+            ],
+            ['scheduler'],
+            'fp',
+        );
+
+        $reporter->report($context);
+
+        self::assertInstanceOf(Email::class, $message);
+        self::assertSame(
+            "The following services are reporting an unhealthy state:\n"
+            . "\n"
+            . "[FAILED] scheduler — Overdue task\n"
+            . "[OK] cache\n",
             $message->getTextBody(),
         );
     }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -50,6 +50,10 @@ provider {
         heartbeatThreshold=900
         # cat=provider/50/30; type=int+; label=Overdue threshold (seconds):Grace period after a task's scheduled next execution time before it is reported as overdue. Tasks configured for manual execution are excluded automatically. Set to 0 to disable. Defaults to 300 (5 minutes).
         overdueThreshold=300
+        # cat=provider/50/40; type=options[Unhealthy (alerts)=unhealthy,Degraded (no alert)=degraded]; label=Overdue task severity:Health state reported when a task is overdue. Unhealthy is an outage (HTTP 503, may notify). Degraded keeps overdue tasks visible on the endpoint (HTTP 200) without notifying. Failed tasks are always unhealthy.
+        overdueSeverity=unhealthy
+        # cat=provider/50/50; type=options[Unhealthy (alerts)=unhealthy,Degraded (no alert)=degraded]; label=Stale heartbeat severity:Health state reported when cron has not invoked the scheduler within the heartbeat threshold. A heartbeat that never ran at all is always unhealthy.
+        heartbeatStaleSeverity=unhealthy
     }
 }
 reportDispatcher {
@@ -59,6 +63,8 @@ reportDispatcher {
     notifyOnRecovery=1
     # cat=reporter/30/30; type=boolean; label=Fail-open on missing state:If notification state is absent (e.g. cache flushed) while status is unhealthy, send (fail-open) rather than stay silent.
     failOpenOnMissingState=1
+    # cat=reporter/30/40; type=options[Unhealthy (default)=unhealthy,Degraded=degraded]; label=Notify from severity:Lowest severity that enters the failure set and is allowed to notify. Unhealthy (default) keeps degraded results as silent HTTP 200; Degraded lets degradation page through the existing reminder/recovery machine.
+    notifyFrom=unhealthy
 }
 
 reporter {


### PR DESCRIPTION
Since #390 a provider can report `healthy`, `degraded` or `unhealthy`. 

This PR here builds on top of that and introduces a new `notifyFrom` option (globally and per provider) letting users decided whether reports / notifications should only be dispatched on `unhealthy` or even `degraded` states.

The dispatcher now builds its failure set from every result whose status is **at least** the configured `reportDispatcher.notifyFrom` floor:

| `notifyFrom` | Pages on            | `degraded` behaviour                          |
|--------------|---------------------|-----------------------------------------------|
| `unhealthy`  | `unhealthy` only    | silent — stays HTTP 200, never notifies (default) |
| `degraded`   | `degraded` + `unhealthy` | enters the failure set and notifies      |

The floor is **global**: it is a single severity gate in front of the one shared dedup/reminder/recovery state machine, not a per-reporter setting.

This is distinct from the per-reporter **threshold** below: `notifyFrom` decides *what counts as a failure* (a severity gate), while a reporter's threshold decides *which decisions* (`Unhealthy` / `Reminder` / `Recovered`) it wants once that failure has been determined.