### PR TITLE
[TASK] Migrate to side-by-side multi-version ddev setup

### DIFF
--- a/.ddev/.setup/scripts/utils.sh
+++ b/.ddev/.setup/scripts/utils.sh
@@ -1,0 +1,563 @@
+#!/bin/bash
+
+# Verbose flag — set VERBOSE=1 (or pass -v/--verbose to `ddev install`) to
+# disable the spinner and stream all command output live.
+VERBOSE="${VERBOSE:-0}"
+
+# Internal state shared between _progress, _done and _progress_exit_trap.
+SPINNER_PID=0
+PROGRESS_ACTIVE=0
+PROGRESS_LOG=""
+PROGRESS_LABEL=""
+
+# Function to display a spinner at the current cursor position (simple colored style)
+function _spinner() {
+    local chars="|/-\\"
+    local delay=0.1
+    local i=0
+
+    while true; do
+        printf "\b\e[36m%c\e[0m" "${chars:$i:1}"
+        ((i++))
+        if [ $i -eq ${#chars} ]; then
+            i=0
+        fi
+        sleep $delay
+    done
+}
+
+function _progress() {
+    PROGRESS_LABEL="$1"
+    printf "%s... " "$1"
+    # Spinner mode only in interactive terminals outside CI and verbose runs.
+    if [[ "$VERBOSE" -eq 0 ]] && [[ -z "$CI" ]] && [[ -z "$GITHUB_ACTIONS" ]] && [[ -z "$GITLAB_CI" ]] && [[ -z "$JENKINS_URL" ]] && [[ -t 1 ]]; then
+      PROGRESS_LOG="$(mktemp)"
+      printf " "
+      _spinner &
+      SPINNER_PID=$!
+      # Save stdout/stderr, capture command output to a logfile so we can
+      # replay it on failure instead of swallowing it into /dev/null.
+      exec 3>&1 4>&2
+      exec >"$PROGRESS_LOG" 2>&1
+      PROGRESS_ACTIVE=1
+    else
+      PROGRESS_LOG=""
+      printf "\n"
+    fi
+}
+
+# Stop the spinner (if running) and restore the original stdout/stderr file
+# descriptors. Idempotent — safe to call when no progress region is active.
+function _stop_spinner() {
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    kill $SPINNER_PID 2>/dev/null || true
+    wait $SPINNER_PID 2>/dev/null || true
+    SPINNER_PID=0
+    exec 1>&3 2>&4
+    PROGRESS_ACTIVE=0
+}
+
+# Replay the captured progress log to the user's terminal, then remove it.
+# No-op when there is no logfile (verbose / non-interactive mode).
+function _replay_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    message red "--- Captured output (${PROGRESS_LABEL# }) ---"
+    cat "$PROGRESS_LOG"
+    message red "--- End of captured output ---"
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
+# Discard the captured progress log without replaying it (success path).
+function _clear_progress_log() {
+    [ -n "$PROGRESS_LOG" ] && [ -f "$PROGRESS_LOG" ] || return 0
+    rm -f "$PROGRESS_LOG"
+    PROGRESS_LOG=""
+}
+
+function _done() {
+    local rc=$?
+    local had_spinner=$PROGRESS_ACTIVE
+    _stop_spinner
+
+    if [ $rc -ne 0 ]; then
+      if [ $had_spinner -eq 1 ]; then
+        printf "\b\e[0m\e[31m✘\e[39m\n"
+      else
+        printf "\e[31m✘\e[39m\n"
+      fi
+      _replay_progress_log
+      exit $rc
+    fi
+
+    if [ $had_spinner -eq 1 ]; then
+      printf "\b\e[0m\e[32m✔\e[39m\n"
+    else
+      printf "\e[32m✔\e[39m\n"
+    fi
+    _clear_progress_log
+}
+
+# EXIT trap: surfaces errors from `set -e` aborts mid-block. Stops any running
+# spinner, restores file descriptors, and dumps the captured log so the user
+# sees the actual command output that failed.
+function _progress_exit_trap() {
+    [ $PROGRESS_ACTIVE -eq 1 ] || return 0
+    _stop_spinner
+    printf "\b\e[0m\e[31m✘\e[39m\n"
+    _replay_progress_log
+}
+trap _progress_exit_trap EXIT
+
+
+# Function to get the lowest supported TYPO3 version from the environment variable TYPO3_VERSIONS
+# It reads the TYPO3_VERSIONS environment variable, splits it into an array, and sorts the versions.
+# If no versions are found, it prints an error message and exits with status 1.
+# Otherwise, it prints the lowest version.
+function get_lowest_supported_typo3_versions() {
+    local TYPO3_VERSIONS_ARRAY=()
+    IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+    if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+        message red "Error! No supported TYPO3 versions found in environment variables."
+        exit 1
+    fi
+    printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}" | sort -V | head -n 1
+}
+
+# Function to get the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# It checks if the TYPO3_VERSIONS environment variable is set and not empty.
+# If the variable is unset or empty, it prints an error message and returns 1.
+# Otherwise, it splits the TYPO3_VERSIONS variable into an array and prints the supported versions.
+function get_supported_typo3_versions() {
+    if [ -z "${TYPO3_VERSIONS+x}" ]; then
+        message red "TYPO3_VERSIONS is unset. Please set it before running this function."
+        return 1
+    else
+        local TYPO3_VERSIONS_ARRAY=()
+        IFS=' ' read -r -a TYPO3_VERSIONS_ARRAY <<< "$TYPO3_VERSIONS"
+        if [ ${#TYPO3_VERSIONS_ARRAY[@]} -eq 0 ]; then
+            message red "Error! No supported TYPO3 versions found in environment variables."
+            return 1
+        fi
+        printf "%s\n" "${TYPO3_VERSIONS_ARRAY[@]}"
+    fi
+}
+
+# Function to check if a given TYPO3 version is supported.
+# It takes one argument, the TYPO3 version to check.
+# The function reads the supported TYPO3 versions from the environment variable TYPO3_VERSIONS.
+# If the provided version is not in the list of supported versions, it prints an error message and exits with status 1.
+# If the provided version is supported, it returns 0.
+#
+# Arguments:
+#   $1 - The TYPO3 version to check.
+#
+# Returns:
+#   0 if the provided TYPO3 version is supported.
+#   1 if the provided TYPO3 version is not supported or if no version is provided.
+function check_typo3_version() {
+    local TYPO3=$1
+    local SUPPORTED_TYPO3_VERSIONS=()
+    local found=0
+
+    if [ -z "$TYPO3" ]; then
+        message red "No TYPO3 version provided. Please set one of the supported TYPO3 versions as argument: $(get_supported_typo3_versions_comma_separated)"
+        exit 1
+    fi
+
+    while IFS= read -r line; do
+        SUPPORTED_TYPO3_VERSIONS+=("$line")
+    done < <(get_supported_typo3_versions)
+
+    for version in "${SUPPORTED_TYPO3_VERSIONS[@]}"; do
+        if [[ "$version" == "$TYPO3" ]]; then
+            found=1
+            break
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        message red "TYPO3 version '$TYPO3' is not supported."
+        exit 1
+    fi
+
+    return 0
+}
+
+# Function to perform pre-setup tasks for TYPO3 installation.
+# It exports the provided TYPO3 version to the VERSION environment variable,
+# displays an introductory message for the TYPO3 version, and starts the installation process.
+#
+# Arguments:
+#   $1 - The TYPO3 version to set up.
+#
+# Usage:
+#   pre_setup <TYPO3_VERSION>
+function pre_setup() {
+  export VERSION=$1
+  message magenta "Install TYPO3 $VERSION"
+  _progress " ├─ Prepare environment"
+    export BASE_PATH="/var/www/html/.Build/$VERSION"
+    intro_typo3
+    message blue "Pre Setup for TYPO3 $VERSION"
+  _done
+  install_start
+  install_composer_packages
+}
+
+# Function to perform post-setup tasks for TYPO3 installation.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and calls the appropriate post-setup function based on the TYPO3 version.
+# After that, it imports data and updates TYPO3.
+function post_setup() {
+  prepare_acceptance_testing
+
+  cd "$BASE_PATH" || { message red "Failed to change to $BASE_PATH"; return 1; }
+  TYPO3_INSTALL_DB_DBNAME=$DATABASE
+
+  _progress " ├─ Setup TYPO3"
+    if [ "$VERSION" == "11" ]; then
+      post_setup_11
+    elif [ "$VERSION" == "12" ]; then
+      post_setup_12
+    elif [ "$VERSION" == "13" ]; then
+      post_setup_13
+    elif [ "$VERSION" == "14" ]; then
+      post_setup_14
+    fi
+  _done
+
+  _progress " ├─ Import data"
+    import_xml_data
+    import_sql_data
+    import_site_configs
+    run_fixture_scripts
+  _done
+  _progress " ├─ Update TYPO3"
+    update_typo3
+  _done
+  printf " └─ \033[33mTYPO3 $VERSION setup completed!\033[0m Open in your browser: https://$VERSION.${EXTENSION_NAME}.ddev.site\n"
+}
+
+# Function to display an introductory message for the TYPO3 version.
+# It prints a formatted message with the TYPO3 version in magenta color.
+function intro_typo3() {
+    message magenta "-------------------------------------------------"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "| \t\t     TYPO3 $VERSION     \t\t|"
+    message magenta "|\t\t\t\t\t\t|"
+    message magenta "-------------------------------------------------"
+}
+
+# Function to start the installation process for TYPO3.
+# It removes any existing files in the test directory for the specified version,
+# sets up the environment, creates symlinks for the main and additional extensions,
+# and sets up Composer for the TYPO3 installation.
+function install_start() {
+    rm -rf /var/www/html/.Build/$VERSION/*
+    _progress " ├─ Setup environment"
+      setup_environment
+    _done
+    _progress " ├─ Create symlinks"
+      create_symlinks_main_extension
+      create_symlinks_additional_extensions
+    _done
+    _progress " ├─ Setup composer"
+      setup_composer
+    _done
+}
+
+# Function to set up the environment for TYPO3 installation.
+# It sets the base path for the TYPO3 installation, removes any existing files in the base path,
+# creates necessary directories, sets permissions, and exports environment variables.
+# Additionally, it drops the existing database for the TYPO3 version.
+function setup_environment() {
+    rm -rf "$BASE_PATH"
+    mkdir -p "$BASE_PATH/packages/$EXTENSION_KEY"
+    chmod 775 -R $BASE_PATH
+    export DATABASE="database_$VERSION"
+    if [ "$VERSION" == "11" ]; then
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3cms"
+    else
+        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
+    fi
+    mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
+}
+
+# Function to create symlinks for the main extension.
+# It iterates over the items in the current directory, excluding certain directories and files,
+# and creates symbolic links for the remaining items in the specified base path.
+function create_symlinks_main_extension() {
+    local exclusions=(".*" "Documentation" "Documentation-GENERATED-temp" "var")
+    for item in ./*; do
+        local base_name=$(basename "$item")
+        for exclusion in "${exclusions[@]}"; do
+            if [[ $base_name == "$exclusion" ]]; then
+                continue 2
+            fi
+        done
+        ln -sr "$item" "$BASE_PATH/packages/$EXTENSION_KEY/$base_name"
+    done
+}
+
+# Function to create symlinks for additional extensions.
+# It iterates over the directories in the specified path and creates symbolic links
+# for each directory in the base path.
+function create_symlinks_additional_extensions() {
+    for dir in Tests/Acceptance/Fixtures/packages/*/; do
+        ln -sr "$dir" "$BASE_PATH/packages/$(basename "$dir")"
+    done
+}
+
+# Function to set up Composer for TYPO3 installation.
+# It initializes a new Composer project in the specified base path,
+# configures the TYPO3 web directory, sets up the repository for packages,
+# and allows necessary Composer plugins.
+function setup_composer() {
+    composer init --name="test/typo3-$VERSION" --description="TYPO3 $VERSION" --no-interaction --working-dir "$BASE_PATH"
+    composer config extra.typo3/cms.web-dir public --working-dir "$BASE_PATH"
+    composer config repositories.packages path 'packages/*' --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/cms-composer-installers true --working-dir "$BASE_PATH"
+    composer config --no-interaction allow-plugins.typo3/class-alias-loader true --working-dir "$BASE_PATH"
+}
+
+# Function to set up TYPO3 configuration.
+# It changes the current directory to the base path, sets the TYPO3 installation database name,
+# and configures various TYPO3 settings such as debug mode, error display, trusted hosts pattern,
+# mail transport, and graphics processor.
+function setup_typo3() {
+    cd "$BASE_PATH" || { message red "Failed to change to $BASE_PATH"; return 1; }
+    export TYPO3_INSTALL_DB_DBNAME=$DATABASE
+    $TYPO3_BIN configuration:set 'BE/debug' 1
+    $TYPO3_BIN configuration:set 'FE/debug' 1
+    $TYPO3_BIN configuration:set 'SYS/devIPmask' '*'
+    $TYPO3_BIN configuration:set 'SYS/displayErrors' 1
+    $TYPO3_BIN configuration:set 'SYS/trustedHostsPattern' "$VERSION.$EXTENSION_NAME.ddev.site"
+    $TYPO3_BIN configuration:set 'MAIL/transport' 'smtp'
+    $TYPO3_BIN configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+    $TYPO3_BIN configuration:set 'GFX/processor' 'ImageMagick'
+    $TYPO3_BIN configuration:set 'GFX/processor_path' '/usr/bin/'
+}
+
+# Function to update TYPO3.
+# It updates the TYPO3 database schema and flushes the cache.
+function update_typo3() {
+    $TYPO3_BIN database:updateschema
+    $TYPO3_BIN cache:flush
+}
+
+# Function to install required Composer packages for TYPO3.
+function install_composer_packages() {
+  _progress " ├─ Install composer packages"
+    composer req typo3/cms-base-distribution:"^$VERSION" \
+            $PACKAGE_NAME:'*@dev' \
+            test/sitepackage:'*@dev' \
+            helhum/typo3-console:'*' \
+            --no-progress -n -d $BASE_PATH
+  _done
+}
+
+# Function to install Codeception and related packages using Composer.
+# It checks if the codeception.yml file exists in the extension's package directory.
+# If the file exists, it installs the necessary Codeception packages, creates symlinks for
+# the codeception.yml file and acceptance tests directory, and builds the Codeception configuration.
+function prepare_acceptance_testing() {
+  if [ ! -f "$BASE_PATH/packages/$EXTENSION_KEY/codeception.yml" ]; then
+      return
+  fi
+  _progress " ├─ Prepare acceptance testing"
+    composer config --no-interaction allow-plugins.codeception/c3 true --working-dir "$BASE_PATH"
+    composer req --dev codeception/codeception:'*' \
+              codeception/module-asserts:'*' \
+              codeception/module-cli:'*' \
+              codeception/module-db:'*' \
+              codeception/module-phpbrowser:'*' \
+              codeception/module-webdriver:'*' \
+              eliashaeussler/typo3-codeception-helper:'*' \
+              typo3/testing-framework:'*' \
+              --no-progress -n -d $BASE_PATH
+
+    ln -sr "$BASE_PATH/packages/$EXTENSION_KEY/codeception.yml" "$BASE_PATH/codeception.yml"
+    mkdir -p "$BASE_PATH/Tests"
+    ln -sr "$BASE_PATH/packages/$EXTENSION_KEY/Tests/Acceptance" "$BASE_PATH/Tests/Acceptance"
+
+    $BASE_PATH/vendor/bin/codecept build -c $BASE_PATH/codeception.yml
+  _done
+}
+
+# Function to import XML data into TYPO3.
+# It sets the public directory and export directory paths, checks for all .xml files in the FIXTURE_DIR,
+# and imports each XML file using TYPO3's import/export tool.
+function import_xml_data() {
+    PUBLIC_DIR="/var/www/html/.Build/${VERSION}/public"
+    EXPORT_DIR="${PUBLIC_DIR}/fileadmin/user_upload/_temp_/importexport"
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    mkdir -p $EXPORT_DIR
+
+    for XML_FILE in "$FIXTURE_DIR"/*.xml; do
+        if [ -f "$XML_FILE" ]; then
+            FILENAME=$(basename "$XML_FILE")
+            message yellow "Importing XML file $FILENAME..."
+            cp "$XML_FILE" "$EXPORT_DIR/"
+            $TYPO3_BIN impexp:import -vvv --force-uid "$EXPORT_DIR/$FILENAME"
+        fi
+    done
+
+    # Check if no XML files were found
+    if ! ls "$FIXTURE_DIR"/*.xml >/dev/null 2>&1; then
+        message yellow "No XML files found in $FIXTURE_DIR. Skipping XML import."
+    fi
+}
+
+# Function to import SQL data into TYPO3.
+# It checks if the SQL data files exists, and if it does, it imports the SQL
+# data into the TYPO3 database using the MySQL command.
+function import_sql_data() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    for DATA_FILE in "$FIXTURE_DIR"/*.sql; do
+        if [ -f "$DATA_FILE" ]; then
+            message yellow "Importing $DATA_FILE..."
+            mysql -h db -u root -p"root" "$DATABASE" < "$DATA_FILE"
+        fi
+    done
+
+    if ! ls "$FIXTURE_DIR"/*.sql >/dev/null 2>&1; then
+        message yellow "No SQL files found in $FIXTURE_DIR. Skipping SQL import."
+    fi
+}
+
+# Function to import site configuration YAML fixtures.
+# It copies each directory under Tests/Acceptance/Fixtures/sites/ to the
+# TYPO3 site configuration path for the current version, replacing
+# VERSION_PLACEHOLDER with the actual version number in the config.yaml.
+function import_site_configs() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures/sites"
+
+    if [ ! -d "$FIXTURE_DIR" ]; then
+        return
+    fi
+
+    TARGET_BASE="/var/www/html/.Build/$VERSION/config/sites"
+
+    mkdir -p "$TARGET_BASE"
+
+    for SITE_DIR in "$FIXTURE_DIR"/*/; do
+        if [ -d "$SITE_DIR" ]; then
+            SITE_NAME=$(basename "$SITE_DIR")
+            message yellow "Importing site config $SITE_NAME..."
+            mkdir -p "$TARGET_BASE/$SITE_NAME"
+            cp -r "$SITE_DIR"* "$TARGET_BASE/$SITE_NAME/"
+            if [ -f "$TARGET_BASE/$SITE_NAME/config.yaml" ]; then
+                sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "$TARGET_BASE/$SITE_NAME/config.yaml"
+            fi
+        fi
+    done
+}
+
+# Function to run shell script fixtures from Tests/Acceptance/Fixtures/.
+# Executes any *.sh scripts found in the fixture directory. Failures are
+# logged but do not abort the setup, so external services (e.g. Solr,
+# Elasticsearch) that are not yet reachable during early provisioning
+# do not break the installation.
+function run_fixture_scripts() {
+    FIXTURE_DIR="/var/www/html/Tests/Acceptance/Fixtures"
+
+    for SCRIPT in "$FIXTURE_DIR"/*.sh; do
+        if [ -f "$SCRIPT" ]; then
+            message yellow "Running fixture script $(basename "$SCRIPT")..."
+            bash "$SCRIPT" || message red "Fixture script $(basename "$SCRIPT") failed (continuing)"
+        fi
+    done
+}
+
+# Function to perform post-setup tasks for TYPO3 version 11.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_11 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+  $TYPO3_BIN configuration:set 'GFX/processor_path_lzw' '/usr/bin/'
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/public/typo3conf/LocalConfiguration.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 12.
+# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
+# and modifying configuration files to enable deprecations and adjust base paths.
+function post_setup_12 {
+  $TYPO3_BIN install:setup -n --database-name $DATABASE
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+
+  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
+}
+
+# Function to perform post-setup tasks for TYPO3 version 13.
+# It creates the TYPO3 database, sets up TYPO3 by running the installation setup,
+# configures TYPO3 settings, and modifies configuration files to enable deprecations.
+function post_setup_13 {
+  mysql -h db -u root -p"root" -e "CREATE DATABASE $DATABASE;"
+  $TYPO3_BIN  setup -n --dbname=$DATABASE --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+}
+
+# Function to perform post-setup tasks for TYPO3 version 14.
+# It creates the TYPO3 database, sets up TYPO3 by running the installation setup,
+# configures TYPO3 settings, and modifies configuration files to enable deprecations.
+function post_setup_14 {
+  mysql -h db -u root -p"root" -e "CREATE DATABASE $DATABASE;"
+  $TYPO3_BIN  setup -n --dbname=$DATABASE --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.${EXTENSION_NAME}.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+  setup_typo3
+
+  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
+}
+
+# Function to display a colored message.
+# It takes two arguments: the color and the message to display.
+# The function supports the following colors: red, green, yellow, blue, magenta, cyan.
+# If an unsupported color is provided, the message is displayed without color.
+#
+# Usage:
+#   message <color> <message>
+#
+# Arguments:
+#   color   - The color to use for the message (red, green, yellow, blue, magenta, cyan).
+#   message - The message to display.
+message() {
+    local color=$1
+    local message=$2
+
+    case $color in
+        red)
+            echo -e "\033[31m$message\033[0m"
+            ;;
+        green)
+            echo -e "\033[32m$message\033[0m"
+            ;;
+        yellow)
+            echo -e "\033[33m$message\033[0m"
+            ;;
+        blue)
+            echo -e "\033[34m$message\033[0m"
+            ;;
+        magenta)
+            echo -e "\033[35m$message\033[0m"
+            ;;
+        cyan)
+            echo -e "\033[36m$message\033[0m"
+            ;;
+        *)
+            echo -e "$message"
+            ;;
+    esac
+}
+export -f message

--- a/.ddev/.setup/templates/index.php
+++ b/.ddev/.setup/templates/index.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+$extensionKey = getenv('EXTENSION_NAME');
+$typo3AdminUser = getenv('TYPO3_SETUP_ADMIN_USERNAME');
+$typo3AdminPassword = getenv('TYPO3_SETUP_ADMIN_PASSWORD');
+$supportedVersions = explode(' ', getenv('TYPO3_VERSIONS'));
+
+// Check if composer.json exists
+$composerJsonPath = __DIR__ . '/../composer.json';
+if (file_exists($composerJsonPath)) {
+    $composerJsonContent = file_get_contents($composerJsonPath);
+    $composerData = json_decode($composerJsonContent, true);
+    $description = $composerData['description'];
+} else {
+    $description = 'composer.json file not found. =(';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo $extensionKey; ?></title>
+    <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+    >
+    <style>
+        .flex {
+            display: flex;
+            gap: 10px;
+        }
+    </style>
+</head>
+<body>
+<header class="container">
+    <h1>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-0.5 -0.5 24 24" id="Typo3-Icon--Streamline-Svg-Logos.svg" height="40" width="40"><path fill="#F49700" d="M9.895582291666667 0.5915863541666667c-0.4094479166666667 0.35015104166666666 -0.7003020833333333 0.7595869791666667 -0.7003020833333333 1.9823292708333333 0 3.32738125 4.19994375 13.322414583333334 7.060448958333334 13.322414583333334 0.32128125 0.004360416666666667 0.6412927083333333 -0.04125625 0.9485583333333334 -0.13522083333333335l-0.0060375 0.0016770833333333334 -0.07309687499999999 0.11725208333333334C14.656414583333333 19.815003125000004 11.685221875 22.70162291666667 9.887244791666667 22.759530208333334L9.832571875000001 22.760416666666668C5.927195833333333 22.760416666666668 0.38405927083333335 10.970137500000002 0.38405927083333335 5.7827270833333335c0 -0.8170270833333334 0.185265 -1.45805625 0.46686645833333335 -1.8563635416666668C2.194099375 2.2849110416666667 6.394071875000001 0.9991703125 9.895582291666667 0.5915863541666667ZM15.379429166666668 0.23958333333333334c3.616366666666667 0 7.236446875 0.5835842708333334 7.236446875 2.6252104166666665 0 4.142515625000001 -2.627055208333333 9.1632 -3.9683864583333337 9.1632 -2.391760416666667 0 -5.372680208333334 -6.652869791666666 -5.372680208333334 -9.980222291666667C13.274809375 0.5304494791666666 13.856541666666667 0.23958333333333334 15.373870833333335 0.23958333333333334h0.0055583333333333335Z" stroke-width="1"></path></svg>
+        <?php echo $extensionKey; ?></h1>
+</header>
+<main class="container">
+    <blockquote><?php echo $description; ?></blockquote>
+    <hr/>
+    <p>Run <code>ddev install all</code> to install all TYPO3 instances below:</p>
+    <?php
+    foreach ($supportedVersions as $version) {
+        $directoryPath = '/var/www/html/.Build/' . $version;
+        if (is_dir($directoryPath)) {
+            echo "<article class='flex'><kbd>{$version}</kbd><div><strong>Frontend</strong><br/><strong>Backend</strong></div><div><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site'>https://{$version}.{$extensionKey}.ddev.site</a><br/><a target='_blank' href='https://{$version}.{$extensionKey}.ddev.site/typo3/?u={$typo3AdminUser}&p={$typo3AdminPassword}'>https://{$version}.{$extensionKey}.ddev.site/typo3</a></div></article>";
+        } else {
+            echo "<article>Version {$version} is not installed. Run <code>ddev install {$version}</code> to install.</article>";
+        }
+    }
+?>
+    <h2>Additional information</h2>
+    <h4>DDEV commands</h4>
+    <?php
+// Directories to scan for DDEV commands
+$directories = [
+    '/var/www/html/.ddev/commands/web',
+    '/var/www/html/.ddev/commands/host',
+];
+
+foreach ($directories as $directory) {
+    foreach (new DirectoryIterator($directory) as $fileInfo) {
+        $filePath = $fileInfo->getPathname();
+        $fileName = $fileInfo->getFilename();
+
+        if ($fileName[0] === '.' || $fileInfo->isDir()) {
+            continue;
+        }
+
+        $fileContent = file($filePath);
+        if (str_starts_with($fileContent[0], '#!/bin/bash')) {
+            $description = '';
+            $usage = '';
+            $example = '';
+
+            foreach ($fileContent as $line) {
+                if (str_starts_with($line, '## Description:')) {
+                    $description = trim(str_replace('## Description:', '', $line));
+                } elseif (str_starts_with($line, '## Usage:')) {
+                    $usage = trim(str_replace('## Usage:', '', $line));
+                } elseif (str_starts_with($line, '## Example:')) {
+                    $example = trim(str_replace('## Example:', '', $line));
+                }
+            }
+
+            echo "<article><code>ddev $usage</code><br/>$description<br/> <em>Example: $example</em></article>";
+        }
+    }
+}
+?>
+    <details open>
+        <summary><h4>TYPO3 Backend Credentials</h4></summary>
+        <ul>
+            <li>Username: <code><?php echo $typo3AdminUser; ?></code></li>
+            <li>Password: <code><?php echo $typo3AdminPassword; ?></code></li>
+        </ul>
+    </details>
+</main>
+
+</body>
+</html>

--- a/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
+++ b/.ddev/addon-metadata/typo3-multi-version-extension/manifest.yaml
@@ -1,0 +1,26 @@
+name: typo3-multi-version-extension
+repository: konradmichalik/ddev-typo3-multi-version-extension
+version: 0.3.3
+install_date: "2026-06-29T11:10:58+02:00"
+project_files:
+    - .setup/scripts/utils.sh
+    - .setup/templates/index.php
+    - .setup/Tests/Acceptance/Fixtures/
+    - apache/10.conf
+    - apache/20.conf
+    - commands/host/launch
+    - commands/web/.install-11
+    - commands/web/.install-12
+    - commands/web/.install-13
+    - commands/web/.install-14
+    - commands/web/11
+    - commands/web/12
+    - commands/web/13
+    - commands/web/14
+    - commands/web/all
+    - commands/web/install
+    - docker-compose.typo3-setup.yaml
+global_files: []
+removal_actions:
+    - rm -f ${DDEV_APPROOT}/.ddev/config.typo3-setup.yaml
+    - rm -rf ${DDEV_APPROOT}/.ddev/.setup/

--- a/.ddev/apache/10.conf
+++ b/.ddev/apache/10.conf
@@ -1,0 +1,43 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName typo3-monitoring.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName typo3-monitoring.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/apache/20.conf
+++ b/.ddev/apache/20.conf
@@ -1,0 +1,51 @@
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-apache-configuration
+<VirtualHost *:80>
+    ServerName sub.typo3-monitoring.ddev.site
+    ServerAlias *.typo3-monitoring.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.typo3-monitoring\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName sub.typo3-monitoring.ddev.site
+    ServerAlias *.typo3-monitoring.ddev.site
+    DocumentRoot /var/www/html/.Build
+    <Directory "/var/www/html/.Build">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    RewriteEngine On
+    RewriteCond %{HTTP_HOST} ^([a-z0-9-]+)\.typo3-monitoring\.ddev\.site$
+    RewriteRule ^(.*)$ /var/www/html/.Build/%1/public/$1 [L]
+
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+</VirtualHost>

--- a/.ddev/commands/web/.install-13
+++ b/.ddev/commands/web/.install-13
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 13.
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 13
+
+#_progress " ├─ Install additional composer packages"
+#  composer req x/y:'^1.0' \
+#          --no-progress -n -d $BASE_PATH
+#_done
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/.install-14
+++ b/.ddev/commands/web/.install-14
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+. .ddev/.setup/scripts/utils.sh
+
+# Pre-setup function for TYPO3 version 14
+# This function is part of the installation script and is responsible for performing
+# initial setup tasks before the main installation process begins.
+pre_setup 14
+
+#_progress " ├─ Install additional composer packages"
+#  composer req x/y:'^1.0' \
+#          --no-progress -n -d $BASE_PATH
+#_done
+
+# Function to perform post-setup tasks.
+# This function is called after the main installation process to finalize the setup.
+# It typically includes tasks such as configuring settings, modifying files, and other necessary adjustments.
+post_setup

--- a/.ddev/commands/web/13
+++ b/.ddev/commands/web/13
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Exec command for TYPO3 instance 13.
+## Usage: 13
+## Example: "ddev 13 composer du -o" or "ddev 13 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=13
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/14
+++ b/.ddev/commands/web/14
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Description: Exec command for TYPO3 instance 14.
+## Usage: 14
+## Example: "ddev 14 composer du -o" or "ddev 14 typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+version=14
+
+if [[ $command == typo3* ]]; then
+    command="/usr/bin/php vendor/bin/${command}"
+fi
+
+TYPO3_PATH=".Build/${version}"
+if [ -d "$TYPO3_PATH" ]; then
+    message magenta "[TYPO3 v${version}] ${command}"
+    cd $TYPO3_PATH
+    $command
+else
+    message red "TYPO3 binary not found for version ${version}"
+fi

--- a/.ddev/commands/web/all
+++ b/.ddev/commands/web/all
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+## Description: Exec command for all TYPO3 instances.
+## Usage: all
+## Example: "ddev all composer du -o" or "ddev all typo3 cache:flush"
+
+. .ddev/.setup/scripts/utils.sh
+
+command=$@
+mapfile -t versions < <(get_supported_typo3_versions)
+
+for version in "${versions[@]}"; do
+    TYPO3_PATH="/var/www/html/.Build/${version}"
+    if [ -d "$TYPO3_PATH" ]; then
+        if [[ $command == typo3* ]]; then
+                tempCommand="/usr/bin/php vendor/bin/${command}"
+            fi
+        fi
+        cd $TYPO3_PATH
+        message magenta "[TYPO3 v${version}] ${tempCommand}"
+        $tempCommand
+    else
+        message red "TYPO3 instance not found for version ${version}"
+    fi
+done

--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+## #ddev-generated
+## Description: Install TYPO3 instances. Pass -v/--verbose to stream all command output.
+## Usage: install [version|all] [-v|--verbose]
+## Example: "ddev install" or "ddev install 12" or "ddev install all" or "ddev install 14 -v"
+## MutagenSync: true
+
+TYPO3=""
+for arg in "$@"; do
+    case "$arg" in
+        -v|--verbose) export VERBOSE=1 ;;
+        *) [ -z "$TYPO3" ] && TYPO3="$arg" ;;
+    esac
+done
+
+. .ddev/.setup/scripts/utils.sh
+
+if [ "$TYPO3" == "all" ]; then
+    mapfile -t versions < <(get_supported_typo3_versions)
+    for version in "${versions[@]}"; do
+        .ddev/commands/web/.install-$version
+    done
+else
+    if [ -z "$TYPO3" ]; then
+        TYPO3=$(get_lowest_supported_typo3_versions)
+    else
+        if ! check_typo3_version "$TYPO3"; then
+            exit 1
+        fi
+    fi
+    ".ddev/commands/web/.install-$TYPO3"
+fi

--- a/.ddev/config.typo3-setup.yaml
+++ b/.ddev/config.typo3-setup.yaml
@@ -1,0 +1,9 @@
+type: php
+docroot: .Build
+webserver_type: apache-fpm
+additional_hostnames:
+  - 13.typo3-monitoring
+  - 14.typo3-monitoring
+hooks:
+   post-start:
+    - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,11 +1,9 @@
 name: typo3-monitoring
-type: typo3
-docroot: .build/web
+type: php
+docroot: public
 php_version: "8.4"
-webserver_type: nginx-fpm
+webserver_type: apache-fpm
 xdebug_enabled: false
-additional_hostnames: []
-additional_fqdns: []
 database:
     type: mariadb
     version: "11.8"
@@ -13,288 +11,30 @@ omit_containers: [ddev-ssh-agent]
 webimage_extra_packages: [php8.4-pcov]
 use_dns_when_possible: true
 composer_version: "2"
-web_environment:
-    - typo3DatabaseUsername=root
-    - typo3DatabasePassword=root
-    - typo3DatabaseName=db
-    - TYPO3_CONTEXT=Development/DDEV
-    - typo3DatabaseHost=db
 corepack_enable: false
 
-# Key features of DDEV's config.yaml:
-
-# name: <projectname> # Name of the project, automatically provides
-#   http://projectname.ddev.site and https://projectname.ddev.site
-# If the name is omitted, the project will take the name of the enclosing directory,
-# which is useful if you want to have a copy of the project side by side with this one.
-
-# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
-# See https://docs.ddev.com/en/stable/users/quickstart/ for more
-# information on the different project types
-
-# docroot: <relative_path> # Relative path to the directory containing index.php.
-
-# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
-
-# You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to DDEV's' behavior,
-# so this can break upgrades.
-
-# webimage: <docker_image>
-# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
-# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
-
-# database:
-#   type: <dbtype> # mysql, mariadb, postgres
-#   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
-#   MySQL versions can be 5.5-8.0, 8.4
-#   PostgreSQL versions can be 9-18
-
-# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
-# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
-
-# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
-# Note that for most people the commands
-# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
-# as leaving Xdebug enabled all the time is a big performance hit.
-
-# xhgui_http_port: "8143"
-# xhgui_https_port: "8142"
-# The XHGui ports can be changed from the default 8143 and 8142
-# Very rarely used
-
-# host_xhgui_port: "8142"
-# Can be used to change the host binding port of the XHGui
-# application. Rarely used; only when port conflict and
-# bind_all_ports is used (normally with router disabled)
-
-# xhprof_mode: [prepend|xhgui|global]
-# Default is "xhgui"
-
-# webserver_type: nginx-fpm, apache-fpm, generic
-
-# timezone: Europe/Berlin
-# If timezone is unset, DDEV will attempt to derive it from the host system timezone
-# using the $TZ environment variable or the /etc/localtime symlink.
-# This is the timezone used in the containers and by PHP;
-# it can be set to any valid timezone,
-# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-# For example Europe/Dublin or MST7MDT
-
-# composer_root: <relative_path>
-# Relative path to the Composer root directory from the project root. This is
-# the directory which contains the composer.json and where all Composer related
-# commands are executed.
-
-# composer_version: "2"
-# You can set it to "" or "2" (default) for Composer v2
-# to use the latest major version available at the time your container is built.
-# It is also possible to use each other Composer version channel. This includes:
-#   - 2.2 (latest Composer LTS version)
-#   - stable
-#   - preview
-#   - snapshot
-# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev utility rebuild".
-
-# nodejs_version: "24"
-# change from the default system Node.js version to any other version.
-# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
-# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
-
-# corepack_enable: false
-# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
-
-# additional_hostnames:
-#  - somename
-#  - someothername
-# would provide http and https URLs for "somename.ddev.site"
-# and "someothername.ddev.site".
-
-# additional_fqdns:
-#  - example.com
-#  - sub1.example.com
-# would provide http and https URLs for "example.com" and "sub1.example.com"
-# Please take care with this because it can cause great confusion.
-
-# upload_dirs: "custom/upload/dir"
+# Multi-version development (TYPO3 v13 + v14)
+# ------------------------------------------
+# This project uses the konradmichalik/ddev-typo3-multi-version-extension add-on
+# to run multiple TYPO3 versions side by side. Each version lives in an isolated
+# instance under .Build/<version>/ with its own composer, vendor, config, public
+# docroot and database; EXT:monitoring is symlinked into every instance.
 #
-# upload_dirs:
-#   - custom/upload/dir
-#   - ../private
+# This base config satisfies the add-on's three requirements:
+#   - project name (`monitoring`) == the extension key
+#   - webserver_type: apache-fpm (nginx-fpm is not supported by the add-on)
+#   - a valid composer.json in the project root
 #
-# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
-# When Mutagen is enabled this path is bind-mounted so that all the files
-# in the upload_dirs don't have to be synced into Mutagen.
-
-# disable_upload_dirs_warning: false
-# If true, turns off the normal warning that says
-# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
-
-# ddev_version_constraint: ""
-# Example:
-# ddev_version_constraint: ">= 1.24.8"
-# This will enforce that the running ddev version is within this constraint.
-# See https://github.com/Masterminds/semver#checking-version-constraints for
-# supported constraint formats
-
-# working_dir:
-#   web: /var/www/html
-#   db: /home
-# would set the default working directory for the web and db services.
-# These values specify the destination directory for ddev ssh and the
-# directory in which commands passed into ddev exec are run.
-
-# omit_containers: [db, ddev-ssh-agent]
-# Currently only these containers are supported. Some containers can also be
-# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
-# the "db" container, several standard features of DDEV that access the
-# database container will be unusable. In the global configuration it is also
-# possible to omit ddev-router, but not here.
-
-# performance_mode: "global"
-# DDEV offers performance optimization strategies to improve the filesystem
-# performance depending on your host system. Should be configured globally.
+# First-time setup (run locally; requires Docker + DDEV):
+#   konradmichalik/ddev-typo3-multi-version-extension
+#   ddev restart
+#   ddev install 13 && ddev install 14    # or: ddev install all
 #
-# If set, will override the global config. Possible values are:
-#   - "global":  uses the value from the global config.
-#   - "none":    disables performance optimization for this project.
-#   - "mutagen": enables Mutagen for this project.
+# Daily usage:
+#   ddev launch 13             # v13 frontend
+#   ddev launch 14 /typo3      # v14 backend, side by side with v13
+#   ddev 13 typo3 cache:flush  # run a command in a single version
+#   ddev all composer update   # run across every installed version
 #
-# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
-
-# fail_on_hook_fail: False
-# Decide whether 'ddev start' should be interrupted by a failing hook
-
-# host_https_port: "59002"
-# The host port binding for https can be explicitly specified. It is
-# dynamic unless otherwise specified.
-# This is not used by most people, most people use the *router* instead
-# of the localhost port.
-
-# host_webserver_port: "59001"
-# The host port binding for the ddev-webserver can be explicitly specified. It is
-# dynamic unless otherwise specified.
-# This is not used by most people, most people use the *router* instead
-# of the localhost port.
-
-# host_db_port: "59002"
-# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
-# unless explicitly specified.
-
-# mailpit_http_port: "8025"
-# mailpit_https_port: "8026"
-# The Mailpit ports can be changed from the default 8025 and 8026
-
-# host_mailpit_port: "8025"
-# The mailpit port is not normally bound on the host at all, instead being routed
-# through ddev-router, but it can be bound directly to localhost if specified here.
-
-# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
-# Extra Debian packages that are needed in the webimage can be added here
-
-# dbimage_extra_packages: [netcat, telnet, sudo]
-# Extra Debian packages that are needed in the dbimage can be added here
-
-# use_dns_when_possible: true
-# If the host has internet access and the domain configured can
-# successfully be looked up, DNS will be used for hostname resolution
-# instead of editing /etc/hosts
-# Defaults to true
-
-# project_tld: ddev.site
-# The top-level domain used for project URLs
-# The default "ddev.site" allows DNS lookup via a wildcard
-
-# share_default_provider: ngrok
-# The default share provider to use for "ddev share"
-# Defaults to global configuration, usually "ngrok"
-# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
-
-# share_provider_args: --basic-auth username:pass1234
-# Provide extra flags to the share provider script
-# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
-
-# disable_settings_management: false
-# If true, DDEV will not create CMS-specific settings files like
-# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
-# In this case the user must provide all such settings.
-
-# You can inject environment variables into the web container with:
-# web_environment:
-#     - SOMEENV=somevalue
-#     - SOMEOTHERENV=someothervalue
-
-# no_project_mount: false
-# (Experimental) If true, DDEV will not mount the project into the web container;
-# the user is responsible for mounting it manually or via a script.
-# This is to enable experimentation with alternate file mounting strategies.
-# For advanced users only!
-
-# bind_all_interfaces: false
-# If true, host ports will be bound on all network interfaces,
-# not the localhost interface only. This means that ports
-# will be available on the local network if the host firewall
-# allows it.
-
-# default_container_timeout: 120
-# The default time that DDEV waits for all containers to become ready can be increased from
-# the default 120. This helps in importing huge databases, for example.
-
-#web_extra_exposed_ports:
-#- name: nodejs
-#  container_port: 3000
-#  http_port: 2999
-#  https_port: 3000
-#- name: something
-#  container_port: 4000
-#  https_port: 4000
-#  http_port: 3999
-# Allows a set of extra ports to be exposed via ddev-router
-# Fill in all three fields even if you don’t intend to use the https_port!
-# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
-#
-# The port behavior on the ddev-webserver must be arranged separately, for example
-# using web_extra_daemons.
-# For example, with a web app on port 3000 inside the container, this config would
-# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
-# web_extra_exposed_ports:
-#  - name: myapp
-#    container_port: 3000
-#    http_port: 9998
-#    https_port: 9999
-
-#web_extra_daemons:
-#- name: "http-1"
-#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
-#  directory: /var/www/html
-#- name: "http-2"
-#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
-#  directory: /var/www/html
-
-# override_config: false
-# By default, config.*.yaml files are *merged* into the configuration
-# But this means that some things can't be overridden
-# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
-# and you can't erase existing hooks or all environment variables.
-# However, with "override_config: true" in a particular config.*.yaml file,
-# 'use_dns_when_possible: false' can override the existing values, and
-# hooks:
-#   post-start: []
-# or
-# web_environment: []
-# or
-# additional_hostnames: []
-# can have their intended affect. 'override_config' affects only behavior of the
-# config.*.yaml file it exists in.
-
-# Many DDEV commands can be extended to run tasks before or after the
-# DDEV command is executed, for example "post-start", "post-import-db",
-# "pre-composer", "post-composer"
-# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
-# information on the commands that can be extended and the tasks you can define
-# for them. Example:
-#hooks:
-#  post-start:
-#    - exec: composer install -d /var/www/html
+# See Documentation/Contributing/MultiVersionDevelopment.md for the full rationale and the
+# fixture override points (Tests/Acceptance/Fixtures/).

--- a/.ddev/docker-compose.typo3-setup.yaml
+++ b/.ddev/docker-compose.typo3-setup.yaml
@@ -1,0 +1,20 @@
+## #ddev-generated
+services:
+    web:
+        environment:
+            - EXTENSION_KEY=typo3_monitoring
+            - EXTENSION_NAME=typo3-monitoring
+            - PACKAGE_NAME=mteu/typo3-monitoring
+            - TYPO3_VERSIONS=12 13 14
+            - SYMLINK_EXCLUSIONS=.* Documentation Documentation-GENERATED-temp var vendor public
+
+            # TYPO3 v13 and v14 config
+            - TYPO3_DB_DRIVER=mysqli
+            - TYPO3_DB_USERNAME=root
+            - TYPO3_DB_PASSWORD=root
+            - TYPO3_DB_HOST=db
+            - TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+            - TYPO3_SETUP_ADMIN_USERNAME=admin
+            - TYPO3_SETUP_ADMIN_PASSWORD=Password1!
+            - TYPO3_PROJECT_NAME=EXT:typo3-monitoring
+            - TYPO3_SERVER_TYPE=apache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.build
+/.Build
+/public
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /config
@@ -6,5 +8,7 @@
 /packages
 /tailor-version-artefact
 /var
-/.ddev/*
-!/.ddev/config.yaml
+# DDEV add-on files (.ddev/commands, docker-compose.*, web-build, …) are meant to
+# be committed so the whole team gets the multi-version setup. DDEV's own
+# generated .ddev/.gitignore excludes the ephemeral/local bits.
+.Build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,59 @@ composer test:unit
 composer test:functional
 ```
 
+#### Testing Against Supported TYPO3 Versions
+
+This extension supports **TYPO3 13.4 & 14.3** on **PHP 8.3, 8.4 and 8.5**. A plain
+`composer install` resolves only the highest combination, so `composer test` then
+covers just one of the combinations CI gates on. For version-sensitive changes,
+verify both lines locally the same way CI does:
+
+```bash
+# Test against TYPO3 v13
+composer update --with=typo3/cms-core:^13.4
+composer test
+
+# Test against TYPO3 v14
+composer update --with=typo3/cms-core:^14.3
+composer test
+
+# Mirror the "lowest" dependency leg of the CI matrix
+composer update --prefer-lowest --with=typo3/cms-core:^13.4
+composer test
+```
+
+The full PHP × TYPO3 × dependencies matrix is enforced in CI
+(`.github/workflows/tests.yaml`).
+
+#### Optional: Run v13 and v14 Side by Side (DDEV)
+
+For manual testing it can help to have both TYPO3 versions running at the same time.
+The committed `.ddev/` config is wired for the
+[`konradmichalik/ddev-typo3-multi-version-extension`][ddev-addon] add-on, which
+provisions an isolated instance per version with this extension symlinked into each.
+
+Requires Docker + DDEV. First-time setup:
+
+```bash
+# macOS only: avoids a BSD-sed "illegal byte sequence" in the add-on's post-install
+export LC_ALL=C LANG=C
+
+ddev add-on get konradmichalik/ddev-typo3-multi-version-extension
+ddev restart
+ddev install 13 && ddev install 14    # or: ddev install all
+```
+
+Daily use:
+
+```bash
+ddev launch 13             # v13 frontend
+ddev launch 14 /typo3      # v14 backend, side by side with v13
+ddev 13 typo3 cache:flush  # run a command in a single version
+ddev all composer update   # run across every installed version
+```
+
+[ddev-addon]: https://github.com/konradmichalik/ddev-typo3-multi-version-extension
+
 #### Code Quality (CGL) Commands
 ```bash
 # Check code style compliance
@@ -60,17 +113,18 @@ composer fix
 
 #### Static Code Analysis (SCA) Commands
 ```bash
-# Run PHPStan analysis with 4GB memory limit
-composer sca:php
-
-# Alternative direct command
-./vendor/bin/phpstan analyse -c Tests/CGL/phpstan.neon --memory-limit=4G
+# Run static analysis (PHPStan with a 4GB memory limit, plus Rector migration checks)
+composer sca
 ```
+
+> Note: `composer sca` also runs `rector process`, which **applies** migration
+> changes to your working tree (it is not a dry run). Commit or stash first if you
+> want to review what it changes.
 
 #### Complete Quality Check
 ```bash
 # Run all quality checks in sequence
-composer lint && composer sca:php && composer test
+composer lint && composer sca && composer test
 ```
 
 ### 4. Testing Requirements
@@ -119,8 +173,9 @@ git push origin feature/your-feature-name
 Before submitting, ensure:
 
 - [ ] **All tests pass**: `composer test`
+- [ ] **Works on both TYPO3 v13 and v14** (test against each, or rely on the CI matrix)
 - [ ] **Code style compliant**: `composer lint`
-- [ ] **Static analysis clean**: `composer sca:php`
+- [ ] **Static analysis clean**: `composer sca`
 - [ ] **New features have tests** (unit or functional)
 - [ ] **Documentation updated** if needed
 - [ ] **Commit messages** are clear and descriptive
@@ -157,10 +212,3 @@ When reporting bugs, please include:
 - Steps to reproduce
 - Expected vs actual behavior
 - Any relevant error messages
-
-## 💡 Questions?
-
-- Check existing [Documentation](Documentation/README.md)
-- Review [Provider Development Guide](Documentation/Providers.md)
-- Look at existing code for patterns
-- Open an issue for discussion

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Services.yaml
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/Configuration/Services.yaml
@@ -1,0 +1,6 @@
+#ddev-generated
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/README.md
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/README.md
@@ -1,0 +1,6 @@
+#ddev-generated
+# Sitepackage
+
+This is a demo sitepackage for testing purposes.
+
+Adjust them to your needs to test features of the main extension.

--- a/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
+++ b/Tests/Acceptance/Fixtures/packages/sitepackage/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "test/sitepackage",
+  "description": "typo3-natural-language-query testing",
+  "license": "GPL-2.0-or-later",
+  "type": "typo3-cms-extension",
+  "authors": [
+    {
+      "name": "#ddev-generated",
+      "email": "x@y.com"
+    }
+  ],
+  "require": {},
+  "suggest": {},
+  "conflict": {},
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "sitepackage"
+    }
+  },
+  "version": "1.0.0",
+  "autoload": {
+    "psr-4": {
+      "Test\\Sitepackage\\": "Classes/"
+    }
+  }
+}


### PR DESCRIPTION
## Run v13 and v14 Side by Side (DDEV)

For manual testing it can help to have both TYPO3 versions running at the same time.
The committed `.ddev/` config is wired for the
[`konradmichalik/ddev-typo3-multi-version-extension`][ddev-addon] add-on, which
provisions an isolated instance per version with this extension symlinked into each.

Requires Docker + DDEV. First-time setup:

```bash
# macOS only: avoids a BSD-sed "illegal byte sequence" in the add-on's post-install
export LC_ALL=C LANG=C

ddev add-on get konradmichalik/ddev-typo3-multi-version-extension
ddev restart
ddev install 13 && ddev install 14    # or: ddev install all
```

Daily use:

```bash
ddev launch 13             # v13 frontend
ddev launch 14 /typo3      # v14 backend, side by side with v13
ddev 13 typo3 cache:flush  # run a command in a single version
ddev all composer update   # run across every installed version
```

[ddev-addon]: https://github.com/konradmichalik/ddev-typo3-multi-version-extension